### PR TITLE
Classic/Retail support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ jdk:
 services:
   - xvfb
 
+script: ./test.sh
+
 # https://github.com/travis-ci/travis-ci/issues/3897
 #branches:
 #    only:

--- a/TODO.md
+++ b/TODO.md
@@ -55,12 +55,6 @@ see CHANGELOG.md for a more formal list of changes by release
     - this will give a *hint* about which version of an addon is installed
 * support for multiple addon directories
     - well, supporting for remembering and quickly switching between addon dirs
-
-
-### todo
-
-* regression, update? column is no longer being populated
-    - all tests passing. this means you need more and better tests
 * classic addons handling
     - curseforge have addons bundling classic versions in with regular versions
         - the api distinguishes them with a 'game_flavour' field
@@ -76,9 +70,29 @@ see CHANGELOG.md for a more formal list of changes by release
                         - (retail, 8.2.0)
                         - (classic-bc, 2.?.?)
                     - https://us.forums.blizzard.com/en/wow/t/will-classic-have-the-expansions-added/133699/19
+    - calling these 'game tracks'
+        - an addon-dir can switch between different tracks and the right release will be downloaded for them
+            - rather than 'the most recent' release
+        - only affects curseforge right now as wowinterface doesn't appear to do 'releases' like cforge does
+        - addons with no release for given track get a warning and nothing is installed
+    - done
+
+
+### todo
+
+* support for multiple addon directories
+    - add ability to remove an addon-dir
+    - add ability to switch between tracks from menu
+        - not really necessary but should make it obvious the 'Addons' menu is affecting the *current addon-dir*
+* regression, update? column is no longer being populated
+    - all tests passing. this means you need more and better tests
 * add checksum checks after downloading
     - curseforge have an md5 that can be used
+        - unfortunately no checksum in api results
+        - they do have a 'fileLength' and a 'fingerprint'
+            - fingerprint is 9 digits and all decimal, so not a hex digest
     - wowinterface checksum is hidden behind a javascript tabber but still available
+        - wowinterface do have a md5sum in results! score
 * can a list of subscribers be setup in github to announce releases?
 * coloured warnings/errors on console output
     - when running with :debug on the wall of text is difficult to read

--- a/TODO.md
+++ b/TODO.md
@@ -55,6 +55,9 @@ see CHANGELOG.md for a more formal list of changes by release
     - this will give a *hint* about which version of an addon is installed
 * support for multiple addon directories
     - well, supporting for remembering and quickly switching between addon dirs
+        - done
+    - add ability to remove an addon-dir
+        - done
 * classic addons handling
     - curseforge have addons bundling classic versions in with regular versions
         - the api distinguishes them with a 'game_flavour' field
@@ -80,8 +83,7 @@ see CHANGELOG.md for a more formal list of changes by release
 
 ### todo
 
-* support for multiple addon directories
-    - add ability to remove an addon-dir
+* classic addons handling
     - add ability to switch between tracks from menu
         - not really necessary but should make it obvious the 'Addons' menu is affecting the *current addon-dir*
 * regression, update? column is no longer being populated

--- a/TODO.md
+++ b/TODO.md
@@ -51,9 +51,16 @@ see CHANGELOG.md for a more formal list of changes by release
     - preserve extended matching (on :name, etc) for addons not yet matched to catalog
     - done
         - I just added another dimension to the matching, nothing else was changed
+* un-hid by default the interface-version column ('WoW') in the installed addons tab
+    - this will give a *hint* about which version of an addon is installed
+* support for multiple addon directories
+    - well, supporting for remembering and quickly switching between addon dirs
+
 
 ### todo
 
+* regression, update? column is no longer being populated
+    - all tests passing. this means you need more and better tests
 * classic addons handling
     - curseforge have addons bundling classic versions in with regular versions
         - the api distinguishes them with a 'game_flavour' field
@@ -111,8 +118,7 @@ see CHANGELOG.md for a more formal list of changes by release
         - if we start doing download concurrently, we need to pass our binds to the threads
             - which I'm not sure if is possible
         - moving back into bucket until I get around to doing parallel downloads
-* support for multiple addon directories
-    - well, supporting for remembering and quickly switching between addon dirs
+
 * 'scrape' and 'update' are not great terms
     - scrape means 'complete update'
     - update means 'partial update'

--- a/src/wowman/catalog.clj
+++ b/src/wowman/catalog.clj
@@ -20,15 +20,15 @@
 (defmulti expand-summary (comp keyword :source))
 
 (defmethod expand-summary :curseforge
-  [addon-summary]
-  (curseforge-api/expand-summary addon-summary))
+  [addon-summary game-track]
+  (curseforge-api/expand-summary addon-summary game-track))
 
 (defmethod expand-summary :wowinterface
-  [addon-summary]
+  [addon-summary game-track]
   (wowinterface-api/expand-summary addon-summary))
 
 (defmethod expand-summary :default
-  [addon-summary]
+  [addon-summary game-track]
   (error "malformed addon-summary:" (utils/pprint addon-summary)))
 
 ;;

--- a/src/wowman/core.clj
+++ b/src/wowman/core.clj
@@ -213,6 +213,11 @@
          new-addon-dir-map-list (mapv tform (get-state :cfg :addon-dir-list))]
      (swap! state update-in [:cfg] assoc :addon-dir-list new-addon-dir-map-list))))
 
+(defn get-game-track
+  ([]
+   (get-game-track (get-state :selected-addon-dir)))
+  ([addon-dir]
+   (-> addon-dir addon-dir-map :game-track)))
 
 ;; settings
 
@@ -573,8 +578,9 @@
 (defn expand-summary-wrapper
   [addon-summary]
   (binding [http/*cache* (cache)]
-    (let [wrapper (affects-addon-wrapper catalog/expand-summary)]
-      (wrapper addon-summary))))
+    (let [game-track (get-game-track) ;; scope creep, but it fits so nicely
+          wrapper (affects-addon-wrapper catalog/expand-summary)]
+      (wrapper addon-summary game-track))))
 
 (defn-spec check-for-updates nil?
   "downloads full details for all installed addons that can be found in summary list"

--- a/src/wowman/core.clj
+++ b/src/wowman/core.clj
@@ -199,9 +199,8 @@
    (dosync
     (let [matching #(= addon-dir (:addon-dir %))
           new-addon-dir-list (->> (get-state :cfg :addon-dir-list) (remove matching) vec)]
-      (info "new addon dir list" new-addon-dir-list)
       (swap! state assoc-in [:cfg :addon-dir-list] new-addon-dir-list)
-      ;; this may be nil if :addon-dir-list is empty
+      ;; this may be nil if the new addon-dir-list is empty
       (swap! state assoc :selected-addon-dir (-> new-addon-dir-list first :addon-dir))))))
 
 (defn available-addon-dirs

--- a/src/wowman/curseforge_api.clj
+++ b/src/wowman/curseforge_api.clj
@@ -86,18 +86,16 @@
    :category-list (sort (mapv :name (:categories snippet)))
    :created-date (:dateCreated snippet) ;; omg *yes*. perfectly formed dates
    ;; we now have :dateModified and :dateReleased to pick from
-   ;; :dateReleased (:fileDate of latest release) appears to be closest to what was being scraped
    ;;:updated-date (:dateModified snippet)
-   :updated-date (:dateReleased snippet)
+   :updated-date (:dateReleased snippet) ;; this seems closest to what we originaly had
    :download-count (-> snippet :downloadCount int) ;; I got a '511.0' ...?
-   :source-id (:id snippet) ;; I imagine wowinterface will have its own as well
-   })
+   :source-id (:id snippet)})
 
 (defn-spec download-summary-page-alphabetically (s/or :ok (s/coll-of map?), :error nil?)
   "downloads a page of results from the curseforge API, sorted A to Z"
   [page int? page-size pos-int?]
   (info "downloading" page-size "results from api, page" page)
-  (let [index (* page-size page) ;; +1 ?
+  (let [index (* page-size page)
         game-id 1 ;; WoW
         sort-by 3 ;; alphabetically, asc (a-z)
         results (http/download (api-uri "/addon/search?gameId=%s&index=%s&pageSize=%s&searchFilter=&sort=%s" game-id index page-size sort-by))

--- a/src/wowman/curseforge_api.clj
+++ b/src/wowman/curseforge_api.clj
@@ -29,7 +29,6 @@
 
   ;; we want to say "give me the latest stable release of the wow classic track of this addon
   ;; for now we're going to ignore anything that isn't a releaseType of 1
-  ;; installing alpha/beta quality addons will come later
 
   (let [latest-files (:latestFiles api-result)
 
@@ -56,18 +55,10 @@
         uri (api-uri "/addon/%s" pid)
         result (-> uri http/download utils/from-json)
 
-        ;;_ (info (utils/pprint (latest-versions-by-game-track result)))
-
         game-track-alias-map {"retail" "wow_retail"
                               "classic" "wow_classic"}
         game-track-alias (game-track-alias-map game-track)
 
-        ;; TODO: this is no longer good enough. we now need to differentiate between regular ('retail') and classic
-        ;; see :gameVersionFlavor
-        ;;latest-release (-> result :latestFiles first) ;; this list isn't sorted!
-        ;; also, :latestFiles seems to be a selection of all files.
-        ;; these files (I think) are selected by release type (alpha/beta/released etc), padded out with the last N proper releases
-        ;;latest-release (->> result :latestFiles (sort-by :fileDate) last)
         latest-release (-> result latest-versions-by-game-track (get game-track-alias) first)]
     (when-not latest-release
       (warn (format "no '%s' release available for '%s'" game-track (:name addon-summary))))

--- a/src/wowman/curseforge_api.clj
+++ b/src/wowman/curseforge_api.clj
@@ -44,7 +44,7 @@
         stable-releases (remove :exposeAsAlternative stable-releases)
 
         ;; I don't know if it's possible, but a group may still have more than one result
-        ;; results are ordered and group-by preserves ordering desc, so take the first
+        ;; results are ordered and group-by preserves ordering, so take the first
         ]
     (group-by :gameVersionFlavor stable-releases)))
 

--- a/src/wowman/specs.clj
+++ b/src/wowman/specs.clj
@@ -118,8 +118,7 @@
 (s/def ::selected? boolean?)
 (s/def ::addon-dir-map (s/keys :req-un [::addon-dir ::game-track]))
 (s/def ::addon-dir-list (s/coll-of ::addon-dir-map))
-(s/def ::user-config (s/keys :req-un [;;::install-dir
-                                      ::addon-dir-list
+(s/def ::user-config (s/keys :req-un [::addon-dir-list
                                       ::debug?]))
 
 (s/def ::reason-phrase (s/and string? #(<= (count %) 50)))

--- a/src/wowman/specs.clj
+++ b/src/wowman/specs.clj
@@ -113,7 +113,14 @@
 
 (s/def ::install-dir (s/nilable ::extant-dir))
 (s/def ::debug? boolean?)
-(s/def ::user-config (s/keys :req-un [::install-dir ::debug?]))
+(s/def ::game-track #{"retail" "classic"})
+(s/def ::addon-dir ::extant-dir)
+(s/def ::selected? boolean?)
+(s/def ::addon-dir-map (s/keys :req-un [::addon-dir ::game-track]))
+(s/def ::addon-dir-list (s/coll-of ::addon-dir-map))
+(s/def ::user-config (s/keys :req-un [;;::install-dir
+                                      ::addon-dir-list
+                                      ::debug?]))
 
 (s/def ::reason-phrase (s/and string? #(<= (count %) 50)))
 (s/def ::status int?) ;; a little too general but ok for now

--- a/src/wowman/ui/gui.clj
+++ b/src/wowman/ui/gui.clj
@@ -24,8 +24,6 @@
    [orchestra.core :refer [defn-spec]]
    [orchestra.spec.test :as st]))
 
-(s/def ::content-pane #(instance? java.awt.Component %))
-
 (defn select-ui
   [& path]
   (if-let [ui (get-state :gui)]
@@ -39,7 +37,8 @@
 (defn inspect
   [x]
   (show-events x)
-  (show-options x))
+  (show-options x)
+  true)
 
 (defn tab
   [title body]
@@ -82,9 +81,12 @@
   [_]
   nil)
 
-(defn handler [& fl]
+(defn handler
+  "returns a function that calls each given argument function sequentially, discards result, returns nil"
+  [& fn-list]
   (fn [_]
-    (doseq [f fl] (f))))
+    (doseq [f fn-list]
+      (f))))
 
 (defn async-handler
   "like `handler`, but each function is executed inside a `go` block instead of sequentially"
@@ -664,18 +666,13 @@
                :title "wowman"
                :size [640 :by 480]
                :content (mig/mig-panel
-                         :constraints (if (core/debugging?)
-                                        ["debug,flowy"]
-                                        ["flowy"])
+                         :constraints ["flowy"] ;; ["debug,flowy"]
                          :items [[root "height 100%, width 100%:100%:100%"]])
                :on-close (if (utils/in-repl?) :dispose :exit)) ;; exit app entirely when not in repl
 
         file-menu (items
                    (ss/action :name "Installed" :key "menu I" :mnemonic "i" :handler (switch-tab-handler INSTALLED-TAB))
                    (ss/action :name "Search" :key "menu H" :mnemonic "h" :handler (switch-tab-handler SEARCH-TAB))
-                   (when (core/debugging?) ;; these have never been useful outside of dev
-                     (ss/action :name "Load settings" :handler (handler core/load-settings))
-                     (ss/action :name "Save settings" :key "menu S" :mnemonic "s" :handler (handler core/save-settings)))
                    :separator
                    (ss/action :name "Exit" :key "menu Q" :mnemonic "x" :handler (handler #(ss/dispose! newui))))
 

--- a/src/wowman/ui/gui.clj
+++ b/src/wowman/ui/gui.clj
@@ -639,11 +639,12 @@
                              ia-count (count ia)
                              uia-count (count uia)
 
-                             strings [(if (= ia-count uia-count)
-                                        all-matching-template
-                                        (format num-matching-template uia-count ia-count))
+                             strings [(format catalog-count-template a-count)
 
-                                      (format catalog-count-template a-count)]]
+                                      (if (= ia-count uia-count)
+                                        all-matching-template
+                                        (format num-matching-template uia-count ia-count))]]
+
                          (ss/text! status (clojure.string/join " " strings))))]
     (state-bind [:installed-addon-list] update-label)
     status))
@@ -695,7 +696,7 @@
                     "Retail"
                     "Classic"
                     :separator
-                    "Remove from list"]
+                    (ss/action :name "Remove from list" :handler (async-handler core/remove-addon-dir!))]
 
         cache-menu [(ss/action :name "Clear cache" :handler (async-handler core/delete-cache))
                     (ss/action :name "Clear addon zips" :handler (async-handler core/delete-downloaded-addon-zips))

--- a/src/wowman/ui/gui.clj
+++ b/src/wowman/ui/gui.clj
@@ -248,10 +248,8 @@
 
         wow-dir-dropdown (ss/combobox :model (core/available-addon-dirs))
 
-        ;; TODO: initial game track version not selected on startup
-        ;; for example, if dir 'foo' is switched to classic, wowman closed and started again, default selected is 'retail'
-
-        wow-game-track (ss/combobox :model core/game-tracks)
+        wow-game-track (ss/combobox :model core/game-tracks
+                                    :selected-item (core/get-game-track))
 
         _ (ss/listen wow-dir-dropdown :selection
                      (async-handler ;; execute elsewhere
@@ -625,13 +623,28 @@
 (defn status-bar
   "this is the litle strip of text at the bottom of the application."
   []
-  (let [template " %s of %s installed addons matched. %s addons in catalog."
-        status (ss/label :text (format template 0 0 0)
+  (let [num-matching-template "%s of %s installed addons found in catalog."
+        all-matching-template "all installed addons found in catalog."
+        catalog-count-template "%s addons in catalog."
+
+        status (ss/label :text ""
                          :font (font :size 11))
+
         update-label (fn [state]
-                       (let [ia (:installed-addon-list state)
-                             uia (filter :matched? ia)]
-                         (ss/text! status (format template (count uia) (count ia) (count (:addon-summary-list state))))))]
+                       (let [a (:addon-summary-list state)
+                             ia (:installed-addon-list state)
+                             uia (filter :matched? ia)
+
+                             a-count (count a)
+                             ia-count (count ia)
+                             uia-count (count uia)
+
+                             strings [(if (= ia-count uia-count)
+                                        all-matching-template
+                                        (format num-matching-template uia-count ia-count))
+
+                                      (format catalog-count-template a-count)]]
+                         (ss/text! status (clojure.string/join " " strings))))]
     (state-bind [:installed-addon-list] update-label)
     status))
 

--- a/src/wowman/ui/gui.clj
+++ b/src/wowman/ui/gui.clj
@@ -286,7 +286,8 @@
                            (debug (format "selected game track changed from %s to %s" old-game-track new-game-track))
                            (ss/invoke-later
                             (core/set-game-track! new-game-track) ;; this will affect [:cfg :addon-dir-list]
-                            (core/save-settings))))))]
+                            ;; will save settings
+                            (core/refresh))))))]
 
     (ss/vertical-panel
      :items [(ss/flow-panel :align :left

--- a/src/wowman/ui/gui.clj
+++ b/src/wowman/ui/gui.clj
@@ -28,7 +28,6 @@
   [& path]
   (if-let [ui (get-state :gui)]
     (ss/select ui (vec path))
-    ;; todo: should this be an assertionerror to match the one in core?
     (throw (RuntimeException. "attempted to access an uninitialised GUI"))))
 
 (def INSTALLED-TAB 0)
@@ -37,8 +36,7 @@
 (defn inspect
   [x]
   (show-events x)
-  (show-options x)
-  true)
+  (show-options x))
 
 (defn tab
   [title body]
@@ -254,7 +252,7 @@
         _ (ss/listen wow-dir-dropdown :selection
                      (async-handler ;; execute elsewhere
                       (fn []
-                        "called when a different addon dir is selected"
+                        ;; called when a different addon dir is selected
                         (let [old-addon-dir (get-state :selected-addon-dir)
                               new-addon-dir (ss/selection wow-dir-dropdown)]
                           (when-not (= new-addon-dir old-addon-dir)
@@ -268,9 +266,9 @@
 
         _ (state-bind [:selected-addon-dir]
                       (fn [state]
-                        "called when the :selected-addon-dir changes (like via `core.set-addon-dir!`)"
+                        ;; called when the :selected-addon-dir changes (like via `core.set-addon-dir!`)
                         (let [new-addon-dir (:selected-addon-dir state)
-                              {:keys [game-track]} (core/addon-dir-map new-addon-dir)
+                              game-track (-> new-addon-dir core/addon-dir-map :game-track)
                               selected-addon-dir (ss/selection wow-dir-dropdown)]
                           (when-not (= selected-addon-dir new-addon-dir)
                             (debug ":selected-addon-dir changed to:" new-addon-dir)
@@ -283,7 +281,7 @@
 
         _ (ss/listen wow-game-track :selection
                      (fn [ev]
-                       "called when a different game track is selected"
+                       ;; called when a different game track is selected
                        (let [new-game-track (ss/selection wow-game-track)
                              old-game-track (:game-track (core/addon-dir-map))]
                          (when-not (= new-game-track old-game-track)
@@ -693,7 +691,7 @@
         addon-menu [(ss/action :name "Update all" :key "menu U" :mnemonic "u" :handler (async-handler core/install-update-all))
                     (ss/action :name "Re-install all" :handler (async-handler core/re-install-all))
                     :separator
-                    (ss/action :name "Remove from list" :handler (async-handler core/remove-addon-dir!))]
+                    (ss/action :name "Remove directory" :handler (async-handler core/remove-addon-dir!))]
 
         cache-menu [(ss/action :name "Clear cache" :handler (async-handler core/delete-cache))
                     (ss/action :name "Clear addon zips" :handler (async-handler core/delete-downloaded-addon-zips))

--- a/src/wowman/ui/gui.clj
+++ b/src/wowman/ui/gui.clj
@@ -693,9 +693,6 @@
         addon-menu [(ss/action :name "Update all" :key "menu U" :mnemonic "u" :handler (async-handler core/install-update-all))
                     (ss/action :name "Re-install all" :handler (async-handler core/re-install-all))
                     :separator
-                    "Retail"
-                    "Classic"
-                    :separator
                     (ss/action :name "Remove from list" :handler (async-handler core/remove-addon-dir!))]
 
         cache-menu [(ss/action :name "Clear cache" :handler (async-handler core/delete-cache))

--- a/src/wowman/ui/gui.clj
+++ b/src/wowman/ui/gui.clj
@@ -273,7 +273,7 @@
                             (ss/invoke-later
                              ;; it's possible the addon-dir-list data has changed as well, so update the dropdown model
                              ;; adding a second listener for :addon-dir-list risks two updates being performed
-                             (ss/config! wow-dir-dropdown :model (core/available-addon-dirs)) 
+                             (ss/config! wow-dir-dropdown :model (core/available-addon-dirs))
                              (ss/selection! wow-dir-dropdown new-addon-dir)
                              (ss/selection! wow-game-track game-track))))))
 

--- a/src/wowman/ui/gui.clj
+++ b/src/wowman/ui/gui.clj
@@ -30,6 +30,7 @@
   [& path]
   (if-let [ui (get-state :gui)]
     (ss/select ui (vec path))
+    ;; todo: should this be an assertionerror to match the one in core?
     (throw (RuntimeException. "attempted to access an uninitialised GUI"))))
 
 (def INSTALLED-TAB 0)
@@ -244,6 +245,9 @@
         wow-dir-button (button "WoW directory" (async-handler picker))
 
         wow-dir-dropdown (ss/combobox :model (core/available-addon-dirs))
+
+        ;; TODO: initial game track version not selected on startup
+        ;; for example, if dir 'foo' is switched to classic, wowman closed and started again, default selected is 'retail'
 
         wow-game-track (ss/combobox :model core/game-tracks)
 

--- a/src/wowman/wowinterface_api.clj
+++ b/src/wowman/wowinterface_api.clj
@@ -7,8 +7,7 @@
     [utils :as utils]
     [specs :as sp]
     [http :as http]]
-   ;;[taoensso.timbre :as log :refer [debug info warn error spy]]
-   ))
+   [taoensso.timbre :as log :refer [debug info warn error spy]]))
 
 (def wowinterface-api "https://api.mmoui.com/v3/game/WOW")
 
@@ -20,10 +19,11 @@
   [addon-summary]
   (let [url (api-uri "/filedetails/%s.json" (:source-id addon-summary))
         ;; returns a map nested in a list? todo: are there any conditions where more than one item is returned?
-        result (-> url http/download utils/from-json first)]
+        result-list (-> url http/download utils/from-json)
+        _ (when (> (count result-list) 1)
+            (warn "wowinterface api returned more than one result for addon with :source-id" (:source-id addon-summary)))
+        result (first result-list)]
     (merge addon-summary {:download-uri (str "https://cdn.wowinterface.com/downloads/getfile.php?id=" (:source-id addon-summary))
-                          :version (:UIVersion result)
-                          ;;:interface-version ;; this is available through the filedetails.json :(
-                          })))
+                          :version (:UIVersion result)})))
 
 (st/instrument)

--- a/src/wowman/wowinterface_api.clj
+++ b/src/wowman/wowinterface_api.clj
@@ -20,9 +20,9 @@
   (let [url (api-uri "/filedetails/%s.json" (:source-id addon-summary))
         ;; returns a map nested in a list? todo: are there any conditions where more than one item is returned?
         result-list (-> url http/download utils/from-json)
-        _ (when (> (count result-list) 1)
-            (warn "wowinterface api returned more than one result for addon with :source-id" (:source-id addon-summary)))
         result (first result-list)]
+    (when (> (count result-list) 1)
+      (warn "wowinterface api returned more than one result for addon with :source-id" (:source-id addon-summary)))
     (merge addon-summary {:download-uri (str "https://cdn.wowinterface.com/downloads/getfile.php?id=" (:source-id addon-summary))
                           :version (:UIVersion result)})))
 

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# (always ratchet threshold upwards)
+lein cloverage --fail-threshold 72 --html

--- a/test/fixtures/curseforge-api-addon--everyaddon.json
+++ b/test/fixtures/curseforge-api-addon--everyaddon.json
@@ -73,7 +73,7 @@
       "gameId": 1,
       "isServerPack": false,
       "serverPackFileId": null,
-      "gameVersionFlavor": "wow_classic"
+      "gameVersionFlavor": "wow_retail"
     }
   ],
   "categories": [
@@ -108,7 +108,7 @@
       "projectFileId": 1,
       "projectFileName": "EveryAddon.zip",
       "fileType": 1,
-      "gameVersionFlavor": "wow_classic"
+      "gameVersionFlavor": "wow_retail"
     }
   ],
   "isFeatured": false,

--- a/test/fixtures/curseforge-api-addon--everyotheraddon.json
+++ b/test/fixtures/curseforge-api-addon--everyotheraddon.json
@@ -73,7 +73,7 @@
       "gameId": 1,
       "isServerPack": false,
       "serverPackFileId": null,
-      "gameVersionFlavor": "wow_classic"
+      "gameVersionFlavor": "wow_retail"
     }
   ],
   "categories": [
@@ -108,7 +108,7 @@
       "projectFileId": 1,
       "projectFileName": "EveryOtherAddon.zip",
       "fileType": 1,
-      "gameVersionFlavor": "wow_classic"
+      "gameVersionFlavor": "wow_retail"
     }
   ],
   "isFeatured": false,

--- a/test/fixtures/curseforge-api-search--truncated.json
+++ b/test/fixtures/curseforge-api-search--truncated.json
@@ -1,0 +1,581 @@
+[
+  {
+    "id": 99982,
+    "name": "AdvancedInterfaceOptions",
+    "authors": [
+      {
+        "name": "Stanzilla",
+        "url": "https://www.curseforge.com/members/293212-stanzilla?username=stanzilla",
+        "projectId": 99982,
+        "id": 76927,
+        "projectTitleId": null,
+        "projectTitleTitle": null,
+        "userId": 293212,
+        "twitchId": 26732732
+      },
+      {
+        "name": "semlar",
+        "url": "https://www.curseforge.com/members/2718421-semlar?username=semlar",
+        "projectId": 99982,
+        "id": 76928,
+        "projectTitleId": 2,
+        "projectTitleTitle": "Author",
+        "userId": 2718421,
+        "twitchId": 47558054
+      }
+    ],
+    "attachments": [
+      {
+        "id": 63046,
+        "projectId": 99982,
+        "description": "",
+        "isDefault": true,
+        "thumbnailUrl": "https://media.forgecdn.net/avatars/thumbnails/63/46/256/256/636142228065658810.png",
+        "title": "636142228065658810.png",
+        "url": "https://media.forgecdn.net/avatars/63/46/636142228065658810.png",
+        "status": 1
+      },
+      {
+        "id": 111241,
+        "projectId": 99982,
+        "description": "<p>The Floating Combat Text Options</p>",
+        "isDefault": false,
+        "thumbnailUrl": "https://media.forgecdn.net/attachments/thumbnails/111/241/310/172/Wow-64_2016-08-15_17-16-12.png",
+        "title": "Wow-64_2016-08-15_17-16-12.png",
+        "url": "https://media.forgecdn.net/attachments/111/241/Wow-64_2016-08-15_17-16-12.png",
+        "status": 1
+      },
+      {
+        "id": 111245,
+        "projectId": 99982,
+        "description": "<p>Basic Options</p>",
+        "isDefault": false,
+        "thumbnailUrl": "https://media.forgecdn.net/attachments/thumbnails/111/245/310/172/WowB-64_2016-06-16_21-03-41.png",
+        "title": "WowB-64_2016-06-16_21-03-41.png",
+        "url": "https://media.forgecdn.net/attachments/111/245/WowB-64_2016-06-16_21-03-41.png",
+        "status": 1
+      },
+      {
+        "id": 111243,
+        "projectId": 99982,
+        "description": "<p>CVar Browser with Search</p>",
+        "isDefault": false,
+        "thumbnailUrl": "https://media.forgecdn.net/attachments/thumbnails/111/243/310/172/WowB-64_2016-06-16_21-04-09.png",
+        "title": "WowB-64_2016-06-16_21-04-09.png",
+        "url": "https://media.forgecdn.net/attachments/111/243/WowB-64_2016-06-16_21-04-09.png",
+        "status": 1
+      },
+      {
+        "id": 111244,
+        "projectId": 99982,
+        "description": "<p>CVar Browser</p>",
+        "isDefault": false,
+        "thumbnailUrl": "https://media.forgecdn.net/attachments/thumbnails/111/244/310/172/WowB-64_2016-06-16_21-03-57.png",
+        "title": "WowB-64_2016-06-16_21-03-57.png",
+        "url": "https://media.forgecdn.net/attachments/111/244/WowB-64_2016-06-16_21-03-57.png",
+        "status": 1
+      }
+    ],
+    "websiteUrl": "https://www.curseforge.com/wow/addons/advancedinterfaceoptions",
+    "gameId": 1,
+    "summary": "Restores access to removed interface options in Legion",
+    "defaultFileId": 2774524,
+    "downloadCount": 2923589,
+    "latestFiles": [
+      {
+        "id": 924345,
+        "displayName": "beta.6",
+        "fileName": "AdvancedInterfaceOptions-beta.6.zip",
+        "fileDate": "2016-07-16T18:01:48.933Z",
+        "fileLength": 19903,
+        "releaseType": 2,
+        "fileStatus": 4,
+        "downloadUrl": "https://edge.forgecdn.net/files/924/345/AdvancedInterfaceOptions-beta.6.zip",
+        "isAlternate": false,
+        "alternateFileId": 0,
+        "dependencies": [],
+        "isAvailable": true,
+        "modules": [
+          {
+            "foldername": "AdvancedInterfaceOptions",
+            "fingerprint": 599349438,
+            "type": 3
+          }
+        ],
+        "packageFingerprint": 3636987504,
+        "gameVersion": [
+          "7.0.3"
+        ],
+        "sortableGameVersion": [
+          {
+            "gameVersionPadded": "0000000007.0000000000.0000000003",
+            "gameVersion": "7.0.3",
+            "gameVersionReleaseDate": "2016-07-19T00:00:00Z",
+            "gameVersionName": "7.0.3"
+          }
+        ],
+        "installMetadata": null,
+        "changelog": null,
+        "hasInstallScript": false,
+        "isCompatibleWithClient": true,
+        "categorySectionPackageType": 1,
+        "restrictProjectFileAccess": 1,
+        "projectStatus": 4,
+        "renderCacheId": 387623,
+        "fileLegacyMappingId": null,
+        "projectId": 99982,
+        "parentProjectFileId": null,
+        "parentFileLegacyMappingId": null,
+        "fileTypeId": null,
+        "exposeAsAlternative": null,
+        "packageFingerprintId": 114394929,
+        "gameVersionDateReleased": "2016-07-19T00:00:00Z",
+        "gameVersionMappingId": 614736,
+        "gameVersionId": 589,
+        "gameId": 1,
+        "isServerPack": false,
+        "serverPackFileId": null,
+        "gameVersionFlavor": "wow_retail"
+      },
+      {
+        "id": 2727265,
+        "displayName": "1.2.12-2-gef0af13",
+        "fileName": "AdvancedInterfaceOptions-1.2.12-2-gef0af13.zip",
+        "fileDate": "2019-06-20T15:33:44.43Z",
+        "fileLength": 42743,
+        "releaseType": 3,
+        "fileStatus": 4,
+        "downloadUrl": "https://edge.forgecdn.net/files/2727/265/AdvancedInterfaceOptions-1.2.12-2-gef0af13.zip",
+        "isAlternate": false,
+        "alternateFileId": 0,
+        "dependencies": [],
+        "isAvailable": true,
+        "modules": [
+          {
+            "foldername": "AdvancedInterfaceOptions",
+            "fingerprint": 1845006304,
+            "type": 3
+          }
+        ],
+        "packageFingerprint": 2311270537,
+        "gameVersion": [
+          "8.1.5"
+        ],
+        "sortableGameVersion": [
+          {
+            "gameVersionPadded": "0000000008.0000000001.0000000005",
+            "gameVersion": "8.1.5",
+            "gameVersionReleaseDate": "2019-03-12T00:00:00Z",
+            "gameVersionName": "8.1.5"
+          }
+        ],
+        "installMetadata": null,
+        "changelog": null,
+        "hasInstallScript": false,
+        "isCompatibleWithClient": true,
+        "categorySectionPackageType": 1,
+        "restrictProjectFileAccess": 1,
+        "projectStatus": 4,
+        "renderCacheId": 1578952,
+        "fileLegacyMappingId": null,
+        "projectId": 99982,
+        "parentProjectFileId": null,
+        "parentFileLegacyMappingId": null,
+        "fileTypeId": null,
+        "exposeAsAlternative": null,
+        "packageFingerprintId": 325580770,
+        "gameVersionDateReleased": "2019-03-12T00:00:00Z",
+        "gameVersionMappingId": 1838603,
+        "gameVersionId": 7262,
+        "gameId": 1,
+        "isServerPack": false,
+        "serverPackFileId": null,
+        "gameVersionFlavor": "wow_retail"
+      },
+      {
+        "id": 2727266,
+        "displayName": "1.2.12-2-gef0af13",
+        "fileName": "AdvancedInterfaceOptions-1.2.12-2-gef0af13-classic.zip",
+        "fileDate": "2019-06-20T15:33:48.73Z",
+        "fileLength": 42743,
+        "releaseType": 3,
+        "fileStatus": 4,
+        "downloadUrl": "https://edge.forgecdn.net/files/2727/266/AdvancedInterfaceOptions-1.2.12-2-gef0af13-classic.zip",
+        "isAlternate": false,
+        "alternateFileId": 0,
+        "dependencies": [],
+        "isAvailable": true,
+        "modules": [
+          {
+            "foldername": "AdvancedInterfaceOptions",
+            "fingerprint": 1845006304,
+            "type": 3
+          }
+        ],
+        "packageFingerprint": 991536247,
+        "gameVersion": [
+          "1.13.2"
+        ],
+        "sortableGameVersion": [
+          {
+            "gameVersionPadded": "0000000001.0000000013.0000000002",
+            "gameVersion": "1.13.2",
+            "gameVersionReleaseDate": "2001-01-01T00:00:00Z",
+            "gameVersionName": "1.13.2"
+          }
+        ],
+        "installMetadata": null,
+        "changelog": null,
+        "hasInstallScript": false,
+        "isCompatibleWithClient": true,
+        "categorySectionPackageType": 1,
+        "restrictProjectFileAccess": 1,
+        "projectStatus": 4,
+        "renderCacheId": 1578953,
+        "fileLegacyMappingId": null,
+        "projectId": 99982,
+        "parentProjectFileId": null,
+        "parentFileLegacyMappingId": null,
+        "fileTypeId": null,
+        "exposeAsAlternative": null,
+        "packageFingerprintId": 325580782,
+        "gameVersionDateReleased": "2001-01-01T00:00:00Z",
+        "gameVersionMappingId": 1838604,
+        "gameVersionId": 7350,
+        "gameId": 1,
+        "isServerPack": false,
+        "serverPackFileId": null,
+        "gameVersionFlavor": "wow_classic"
+      },
+      {
+        "id": 2774524,
+        "displayName": "1.3.2",
+        "fileName": "AdvancedInterfaceOptions-1.3.2.zip",
+        "fileDate": "2019-08-30T14:39:39.89Z",
+        "fileLength": 42654,
+        "releaseType": 1,
+        "fileStatus": 4,
+        "downloadUrl": "https://edge.forgecdn.net/files/2774/524/AdvancedInterfaceOptions-1.3.2.zip",
+        "isAlternate": false,
+        "alternateFileId": 0,
+        "dependencies": [],
+        "isAvailable": true,
+        "modules": [
+          {
+            "foldername": "AdvancedInterfaceOptions",
+            "fingerprint": 1974670497,
+            "type": 3
+          }
+        ],
+        "packageFingerprint": 4273948722,
+        "gameVersion": [
+          "8.2.0"
+        ],
+        "sortableGameVersion": [
+          {
+            "gameVersionPadded": "0000000008.0000000002.0000000000",
+            "gameVersion": "8.2.0",
+            "gameVersionReleaseDate": "2019-06-25T00:00:00Z",
+            "gameVersionName": "8.2.0"
+          }
+        ],
+        "installMetadata": null,
+        "changelog": null,
+        "hasInstallScript": false,
+        "isCompatibleWithClient": true,
+        "categorySectionPackageType": 1,
+        "restrictProjectFileAccess": 1,
+        "projectStatus": 4,
+        "renderCacheId": 1639623,
+        "fileLegacyMappingId": null,
+        "projectId": 99982,
+        "parentProjectFileId": null,
+        "parentFileLegacyMappingId": null,
+        "fileTypeId": null,
+        "exposeAsAlternative": null,
+        "packageFingerprintId": 351408298,
+        "gameVersionDateReleased": "2019-06-25T00:00:00Z",
+        "gameVersionMappingId": 1916538,
+        "gameVersionId": 7417,
+        "gameId": 1,
+        "isServerPack": false,
+        "serverPackFileId": null,
+        "gameVersionFlavor": "wow_retail"
+      },
+      {
+        "id": 2774525,
+        "displayName": "1.3.2-classic",
+        "fileName": "AdvancedInterfaceOptions-1.3.2-classic.zip",
+        "fileDate": "2019-08-30T14:39:44.943Z",
+        "fileLength": 42653,
+        "releaseType": 1,
+        "fileStatus": 4,
+        "downloadUrl": "https://edge.forgecdn.net/files/2774/525/AdvancedInterfaceOptions-1.3.2-classic.zip",
+        "isAlternate": false,
+        "alternateFileId": 0,
+        "dependencies": [],
+        "isAvailable": true,
+        "modules": [
+          {
+            "foldername": "AdvancedInterfaceOptions",
+            "fingerprint": 3586248084,
+            "type": 3
+          }
+        ],
+        "packageFingerprint": 3413475370,
+        "gameVersion": [
+          "1.13.2"
+        ],
+        "sortableGameVersion": [
+          {
+            "gameVersionPadded": "0000000001.0000000013.0000000002",
+            "gameVersion": "1.13.2",
+            "gameVersionReleaseDate": "2001-01-01T00:00:00Z",
+            "gameVersionName": "1.13.2"
+          }
+        ],
+        "installMetadata": null,
+        "changelog": null,
+        "hasInstallScript": false,
+        "isCompatibleWithClient": true,
+        "categorySectionPackageType": 1,
+        "restrictProjectFileAccess": 1,
+        "projectStatus": 4,
+        "renderCacheId": 1639624,
+        "fileLegacyMappingId": null,
+        "projectId": 99982,
+        "parentProjectFileId": null,
+        "parentFileLegacyMappingId": null,
+        "fileTypeId": null,
+        "exposeAsAlternative": null,
+        "packageFingerprintId": 351408310,
+        "gameVersionDateReleased": "2001-01-01T00:00:00Z",
+        "gameVersionMappingId": 1916539,
+        "gameVersionId": 7350,
+        "gameId": 1,
+        "isServerPack": false,
+        "serverPackFileId": null,
+        "gameVersionFlavor": "wow_classic"
+      }
+    ],
+    "categories": [
+      {
+        "categoryId": 1017,
+        "name": "Miscellaneous",
+        "url": "https://www.curseforge.com/wow/addons/miscellaneous",
+        "avatarUrl": "https://media.forgecdn.net/avatars/54/453/636135209712202362.png",
+        "parentId": 1,
+        "rootId": 1,
+        "projectId": 99982,
+        "avatarId": 54453,
+        "gameId": 1
+      },
+      {
+        "categoryId": 1017,
+        "name": "Miscellaneous",
+        "url": "https://www.curseforge.com/wow/addons/miscellaneous",
+        "avatarUrl": "https://media.forgecdn.net/avatars/54/453/636135209712202362.png",
+        "parentId": 1,
+        "rootId": 1,
+        "projectId": 99982,
+        "avatarId": 54453,
+        "gameId": 1
+      }
+    ],
+    "status": 4,
+    "primaryCategoryId": 1017,
+    "categorySection": {
+      "id": 1,
+      "gameId": 1,
+      "name": "Addons",
+      "packageType": 1,
+      "path": "Interface\\Addons",
+      "initialInclusionPattern": "(?i)^([^/]+)[\\\\/]\\1\\.toc$",
+      "extraIncludePattern": "(?i)^[^/\\\\]+[/\\\\]Bindings\\.xml$",
+      "gameCategoryId": 1
+    },
+    "slug": "advancedinterfaceoptions",
+    "gameVersionLatestFiles": [
+      {
+        "gameVersion": "1.13.2",
+        "projectFileId": 2774525,
+        "projectFileName": "AdvancedInterfaceOptions-1.3.2-classic.zip",
+        "fileType": 1,
+        "gameVersionFlavor": "wow_classic"
+      },
+      {
+        "gameVersion": "8.2.0",
+        "projectFileId": 2774524,
+        "projectFileName": "AdvancedInterfaceOptions-1.3.2.zip",
+        "fileType": 1,
+        "gameVersionFlavor": "wow_retail"
+      },
+      {
+        "gameVersion": "1.13.2",
+        "projectFileId": 2727266,
+        "projectFileName": "AdvancedInterfaceOptions-1.2.12-2-gef0af13-classic.zip",
+        "fileType": 3,
+        "gameVersionFlavor": "wow_classic"
+      },
+      {
+        "gameVersion": "8.1.5",
+        "projectFileId": 2727265,
+        "projectFileName": "AdvancedInterfaceOptions-1.2.12-2-gef0af13.zip",
+        "fileType": 3,
+        "gameVersionFlavor": "wow_retail"
+      },
+      {
+        "gameVersion": "8.1.5",
+        "projectFileId": 2724354,
+        "projectFileName": "AdvancedInterfaceOptions-1.2.12.zip",
+        "fileType": 1,
+        "gameVersionFlavor": "wow_retail"
+      },
+      {
+        "gameVersion": "8.1.0",
+        "projectFileId": 2647622,
+        "projectFileName": "AdvancedInterfaceOptions-1.2.9.zip",
+        "fileType": 1,
+        "gameVersionFlavor": "wow_retail"
+      },
+      {
+        "gameVersion": "8.1.0",
+        "projectFileId": 2647621,
+        "projectFileName": "AdvancedInterfaceOptions-1.2.8-1-gb95519e-alpha.zip",
+        "fileType": 3,
+        "gameVersionFlavor": "wow_retail"
+      },
+      {
+        "gameVersion": "8.0.1",
+        "projectFileId": 2623029,
+        "projectFileName": "AdvancedInterfaceOptions-1.2.8.zip",
+        "fileType": 1,
+        "gameVersionFlavor": "wow_retail"
+      },
+      {
+        "gameVersion": "8.0.1",
+        "projectFileId": 2623028,
+        "projectFileName": "AdvancedInterfaceOptions-1.2.7-1-g48f0d5d-alpha.zip",
+        "fileType": 3,
+        "gameVersionFlavor": "wow_retail"
+      },
+      {
+        "gameVersion": "7.3.5",
+        "projectFileId": 2484814,
+        "projectFileName": "AdvancedInterfaceOptions-1.2.2.zip",
+        "fileType": 1,
+        "gameVersionFlavor": "wow_retail"
+      },
+      {
+        "gameVersion": "7.3.0",
+        "projectFileId": 2484814,
+        "projectFileName": "AdvancedInterfaceOptions-1.2.2.zip",
+        "fileType": 1,
+        "gameVersionFlavor": "wow_retail"
+      },
+      {
+        "gameVersion": "7.3.2",
+        "projectFileId": 2484814,
+        "projectFileName": "AdvancedInterfaceOptions-1.2.2.zip",
+        "fileType": 1,
+        "gameVersionFlavor": "wow_retail"
+      },
+      {
+        "gameVersion": "7.2.5",
+        "projectFileId": 2435289,
+        "projectFileName": "AdvancedInterfaceOptions-1.1.4-1-g4858b3f-alpha.zip",
+        "fileType": 3,
+        "gameVersionFlavor": "wow_retail"
+      },
+      {
+        "gameVersion": "7.2.0",
+        "projectFileId": 2415252,
+        "projectFileName": "AdvancedInterfaceOptions-1.1.4.zip",
+        "fileType": 1,
+        "gameVersionFlavor": "wow_retail"
+      },
+      {
+        "gameVersion": "7.2.0",
+        "projectFileId": 2412788,
+        "projectFileName": "AdvancedInterfaceOptions-1.1.3-6-gca31774-alpha.zip",
+        "fileType": 3,
+        "gameVersionFlavor": "wow_retail"
+      },
+      {
+        "gameVersion": "7.1.5",
+        "projectFileId": 2376060,
+        "projectFileName": "AdvancedInterfaceOptions-1.1.0.zip",
+        "fileType": 1,
+        "gameVersionFlavor": "wow_retail"
+      },
+      {
+        "gameVersion": "7.1.5",
+        "projectFileId": 2372910,
+        "projectFileName": "AdvancedInterfaceOptions-23e9754-alpha.zip",
+        "fileType": 3,
+        "gameVersionFlavor": "wow_retail"
+      },
+      {
+        "gameVersion": "7.1.0",
+        "projectFileId": 2353759,
+        "projectFileName": "AdvancedInterfaceOptions-1.0.8.zip",
+        "fileType": 1,
+        "gameVersionFlavor": "wow_retail"
+      },
+      {
+        "gameVersion": "7.1.0",
+        "projectFileId": 2353758,
+        "projectFileName": "AdvancedInterfaceOptions-bc4ea03-alpha.zip",
+        "fileType": 3,
+        "gameVersionFlavor": "wow_retail"
+      },
+      {
+        "gameVersion": "7.0.3",
+        "projectFileId": 947098,
+        "projectFileName": "AdvancedInterfaceOptions-1.0.5-6-g9186ec9.zip",
+        "fileType": 3,
+        "gameVersionFlavor": "wow_retail"
+      },
+      {
+        "gameVersion": "7.0.3",
+        "projectFileId": 936645,
+        "projectFileName": "AdvancedInterfaceOptions-1.0.5.zip",
+        "fileType": 1,
+        "gameVersionFlavor": "wow_retail"
+      },
+      {
+        "gameVersion": "7.0.3",
+        "projectFileId": 924345,
+        "projectFileName": "AdvancedInterfaceOptions-beta.6.zip",
+        "fileType": 2,
+        "gameVersionFlavor": "wow_retail"
+      },
+      {
+        "gameVersion": "6.2.4",
+        "projectFileId": 918696,
+        "projectFileName": "AdvancedInterfaceOptions-beta.3.zip",
+        "fileType": 2,
+        "gameVersionFlavor": "wow_retail"
+      },
+      {
+        "gameVersion": "6.2.4",
+        "projectFileId": 918695,
+        "projectFileName": "AdvancedInterfaceOptions-beta.2-8-g8aaa8ae.zip",
+        "fileType": 3,
+        "gameVersionFlavor": "wow_retail"
+      }
+    ],
+    "isFeatured": false,
+    "popularityScore": 18631.87890625,
+    "gamePopularityRank": 59,
+    "primaryLanguage": "enUS",
+    "gameSlug": "wow",
+    "gameName": "World of Warcraft",
+    "portalName": "www.curseforge.com",
+    "dateModified": "2019-08-30T14:40:33.22Z",
+    "dateCreated": "2016-05-09T17:21:30.1Z",
+    "dateReleased": "2019-08-30T14:39:44.943Z",
+    "isAvailable": true,
+    "isExperiemental": false
+  }
+]

--- a/test/wowman/core_test.clj
+++ b/test/wowman/core_test.clj
@@ -106,7 +106,7 @@
     (try
       (main/start {:ui :cli})
       (let [;; will trigger a refresh. call it here before it affects our crafted state
-            _ (core/set-install-dir! (str fs/*cwd*))
+            _ (core/set-addon-dir! (str fs/*cwd*))
 
             ;; add catalog to app state
             addon-summary-list (utils/load-json-file (fixture-path "import--dummy-catalog.json"))

--- a/test/wowman/curseforge_api_test.clj
+++ b/test/wowman/curseforge_api_test.clj
@@ -55,7 +55,7 @@
           game-track "classic"
           expected nil]
       (with-fake-routes-in-isolation fake-routes
-        (is (= expected (curseforge-api/expand-summary addon-summary game-track)))))))          
+        (is (= expected (curseforge-api/expand-summary addon-summary game-track)))))))
 
 (deftest latest-versions-by-game-track
   (testing "data in :latestFiles is filtered and grouped correctly"
@@ -76,4 +76,22 @@
           expected {"wow_retail" [{:gameVersionFlavor "wow_retail", :fileDate "2001-01-01T00:00:00.000Z", :releaseType stable, :exposeAsAlternative nil}]
                     "wow_classic" [{:gameVersionFlavor "wow_classic", :fileDate "2001-01-01T00:00:00.000Z", :releaseType stable, :exposeAsAlternative nil}]}]
       (is (= expected (curseforge-api/latest-versions-by-game-track fixture))))))
+
+(deftest extract-addon-summary
+  (testing "data extracted from curseforge api 'search' results is correct"
+    (let [fixture (slurp (fixture-path "curseforge-api-search--truncated.json"))
+          fake-routes {"https://addons-ecs.forgesvc.net/api/v2/addon/search?gameId=1&index=0&pageSize=255&searchFilter=&sort=3"
+                       {:get (fn [req] {:status 200 :body fixture})}}
+          expected [{:created-date "2016-05-09T17:21:30.1Z",
+                     :description "Restores access to removed interface options in Legion",
+                     :category-list '("Miscellaneous" "Miscellaneous"),
+                     :updated-date "2019-08-30T14:39:44.943Z",
+                     :name "advancedinterfaceoptions",
+                     :alt-name "advancedinterfaceoptions",
+                     :label "AdvancedInterfaceOptions",
+                     :download-count 2923589,
+                     :source-id 99982,
+                     :uri "https://www.curseforge.com/wow/addons/advancedinterfaceoptions"}]]
+      (with-fake-routes-in-isolation fake-routes
+        (is (= expected (curseforge-api/download-all-summaries-alphabetically)))))))
 

--- a/test/wowman/curseforge_api_test.clj
+++ b/test/wowman/curseforge_api_test.clj
@@ -8,7 +8,7 @@
     [test-helper :as helper :refer [fixture-path temp-path]]]))
 
 (deftest expand-summary
-  (testing "curseforge-api addon expansion"
+  (testing "simple addon expansion, ideal conditions"
     (let [api-results (slurp (fixture-path "curseforge-api-addon--everyaddon.json"))
           fake-routes {"https://addons-ecs.forgesvc.net/api/v2/addon/1"
                        {:get (fn [req] {:status 200 :body api-results})}}
@@ -31,9 +31,31 @@
           expected (merge addon-summary {:download-uri "https://edge.forgecdn.net/files/1/1/EveryAddon.zip"
                                          :version "v8.2.0-v1.13.2-7135.139"
                                          :interface-version 11300 ;; "1.13.2" => 11300
-                                         })]
+                                         })
+          game-track "retail"]
       (with-fake-routes-in-isolation fake-routes
-        (is (= expected (curseforge-api/expand-summary addon-summary "retail")))))))
+        (is (= expected (curseforge-api/expand-summary addon-summary game-track))))))
+
+  (testing "addon expansion when selected game track doesn't match anything available in releases"
+    (let [api-results (slurp (fixture-path "curseforge-api-addon--everyaddon.json"))
+          fake-routes {"https://addons-ecs.forgesvc.net/api/v2/addon/1"
+                       {:get (fn [req] {:status 200 :body api-results})}}
+          addon-summary {:created-date "2010-05-07T18:48:16Z",
+                         :description "Does what no other addon does, slightly differently",
+                         :category-list ["Bags & Inventory"],
+                         :updated-date "2019-06-26T01:21:39Z",
+                         :age "new",
+                         :name "everyaddon",
+                         :source "curseforge",
+                         :alt-name "everyaddon",
+                         :label "EveryAddon",
+                         :download-count 3000000,
+                         :source-id 1,
+                         :uri "https://www.curseforge.com/wow/addons/everyaddon"}
+          game-track "classic"
+          expected nil]
+      (with-fake-routes-in-isolation fake-routes
+        (is (= expected (curseforge-api/expand-summary addon-summary game-track)))))))          
 
 (deftest latest-versions-by-game-track
   (testing "data in :latestFiles is filtered and grouped correctly"

--- a/test/wowman/curseforge_api_test.clj
+++ b/test/wowman/curseforge_api_test.clj
@@ -34,3 +34,24 @@
                                          })]
       (with-fake-routes-in-isolation fake-routes
         (is (= expected (curseforge-api/expand-summary addon-summary "retail")))))))
+
+(deftest latest-versions-by-game-track
+  (testing "data in :latestFiles is filtered and grouped correctly"
+    (let [[alpha, beta, stable] [3 2 1]
+          latest-files [;; retail versions
+                        {:gameVersionFlavor "wow_retail", :fileDate "2001-01-03T00:00:00.000Z", :releaseType alpha, :exposeAsAlternative nil}
+                        {:gameVersionFlavor "wow_retail", :fileDate "2001-01-02T00:00:00.000Z", :releaseType beta, :exposeAsAlternative nil}
+                        {:gameVersionFlavor "wow_retail", :fileDate "2001-01-01T00:00:00.000Z", :releaseType stable, :exposeAsAlternative nil}
+                        {:gameVersionFlavor "wow_retail", :fileDate "2001-01-01T00:00:00.000Z", :releaseType stable, :exposeAsAlternative true}
+
+                        ;; classic versions, mirror retail releases
+                        {:gameVersionFlavor "wow_classic", :fileDate "2001-01-03T00:00:00.000Z", :releaseType alpha, :exposeAsAlternative nil}
+                        {:gameVersionFlavor "wow_classic", :fileDate "2001-01-02T00:00:00.000Z", :releaseType beta, :exposeAsAlternative nil}
+                        {:gameVersionFlavor "wow_classic", :fileDate "2001-01-01T00:00:00.000Z", :releaseType stable, :exposeAsAlternative nil}
+                        {:gameVersionFlavor "wow_classic", :fileDate "2001-01-01T00:00:00.000Z", :releaseType stable, :exposeAsAlternative true}]
+
+          fixture {:latestFiles latest-files}
+          expected {"wow_retail" [{:gameVersionFlavor "wow_retail", :fileDate "2001-01-01T00:00:00.000Z", :releaseType stable, :exposeAsAlternative nil}]
+                    "wow_classic" [{:gameVersionFlavor "wow_classic", :fileDate "2001-01-01T00:00:00.000Z", :releaseType stable, :exposeAsAlternative nil}]}]
+      (is (= expected (curseforge-api/latest-versions-by-game-track fixture))))))
+

--- a/test/wowman/curseforge_api_test.clj
+++ b/test/wowman/curseforge_api_test.clj
@@ -33,4 +33,4 @@
                                          :interface-version 11300 ;; "1.13.2" => 11300
                                          })]
       (with-fake-routes-in-isolation fake-routes
-        (is (= expected (curseforge-api/expand-summary addon-summary)))))))
+        (is (= expected (curseforge-api/expand-summary addon-summary "retail")))))))

--- a/test/wowman/gui_test.clj
+++ b/test/wowman/gui_test.clj
@@ -1,16 +1,12 @@
 (ns wowman.gui-test
   (:require
-   [envvar.core :refer [env with-env]]
-   [clj-http.fake :refer [with-fake-routes-in-isolation]]
    [clojure.test :refer [deftest testing is use-fixtures]]
    [wowman.ui.gui :as gui]
    [wowman
     [main :as main]
-    [core :as core]
-    [utils :as utils :refer [join]]
     [test-helper :as helper :refer [fixture-path temp-path]]]
-   [me.raynes.fs :as fs :refer [with-cwd]]
-   [taoensso.timbre :as log :refer [debug info warn error spy]]))
+  ;;[taoensso.timbre :as log :refer [debug info warn error spy]]
+   ))
 
 (use-fixtures :each helper/fixture-tempcwd)
 
@@ -27,4 +23,13 @@
       (main/start {:ui :cli})
       (is (thrown? RuntimeException (gui/select-ui :#root)))
       (finally
-        (main/stop)))))
+        (main/stop))))
+
+  (testing "gui debug tools don't require an initialised anything in order to be accessed"
+    (with-out-str ;; hide the debug output
+      (is (gui/inspect (seesaw.core/vertical-panel))))))
+
+(deftest gui-stateless-calls
+  (testing "shameless coverage bump for all the stateless parts in gui"
+    (is (= nil (gui/donothing "event object")))
+    (is (= nil ((gui/handler (constantly :foo) (constantly :bar)) "event object")))))

--- a/test/wowman/gui_test.clj
+++ b/test/wowman/gui_test.clj
@@ -27,7 +27,7 @@
 
   (testing "gui debug tools don't require an initialised anything in order to be accessed"
     (with-out-str ;; hide the debug output
-      (is (gui/inspect (seesaw.core/vertical-panel))))))
+      (is (nil? (gui/inspect (seesaw.core/vertical-panel)))))))
 
 (deftest gui-stateless-calls
   (testing "shameless coverage bump for all the stateless parts in gui"

--- a/test/wowman/gui_test.clj
+++ b/test/wowman/gui_test.clj
@@ -7,39 +7,17 @@
    [wowman
     [main :as main]
     [core :as core]
-    [utils :as utils :refer [join]]]
+    [utils :as utils :refer [join]]
+    [test-helper :as helper :refer [fixture-path temp-path]]]
    [me.raynes.fs :as fs :refer [with-cwd]]
    [taoensso.timbre :as log :refer [debug info warn error spy]]))
 
-(defn tempcwd-fixture
-  "each test is executed in a new location (accessible as fs/*cwd*)"
-  [f]
-  (let [temp-dir-path (fs/temp-dir "wowman.main-test.")
-        fake-routes {;; catalog
-                     core/remote-catalog
-                     ;; return dummy data. we can do this because the catalog isn't loaded/parsed/validated
-                     ;; until the UI (gui or cli) tells it to via a later call to `refresh`
-                     {:get (fn [req] {:status 200 :body "{}"})}
-
-                     ;; latest wowman version
-                     "https://api.github.com/repos/ogri-la/wowman/releases/latest"
-                     {:get (fn [req] {:status 200 :body "{\"tag_name\": \"0.0.0\"}"})}}]
-    (try
-      (with-fake-routes-in-isolation fake-routes
-        (with-env [:xdg-data-home (join temp-dir-path "data")
-                   :xdg-config-home (join temp-dir-path "config")]
-          ;; Is this still necessary any more? I guess it improves test isolation
-          (with-cwd temp-dir-path
-            (debug "created temp working directory" fs/*cwd*)
-            (main/start {:ui :gui})
-            (f))))
-      (finally
-        (main/stop)
-        (debug "destroying temp working directory" fs/*cwd*) ;; "with contents" (vec (file-seq fs/*cwd*)))
-        (fs/delete-dir temp-dir-path)))))
-
-(use-fixtures :each tempcwd-fixture)
+(use-fixtures :each helper/fixture-tempcwd)
 
 (deftest gui-init
   (testing "the gui can be started and stopped"
-    (is (gui/select-ui :#root))))
+    (try
+      (main/start {:ui :gui})
+      (is (gui/select-ui :#root))
+      (finally
+        (main/stop)))))

--- a/test/wowman/gui_test.clj
+++ b/test/wowman/gui_test.clj
@@ -20,4 +20,11 @@
       (main/start {:ui :gui})
       (is (gui/select-ui :#root))
       (finally
+        (main/stop))))
+
+  (testing "attempting to select bits of the gui when not the app is started but the gui isn't causes a runtime error"
+    (try
+      (main/start {:ui :cli})
+      (is (thrown? RuntimeException (gui/select-ui :#root)))
+      (finally
         (main/stop)))))

--- a/test/wowman/main_test.clj
+++ b/test/wowman/main_test.clj
@@ -65,7 +65,7 @@
     (is (= :cli (-> (main/parse ["--action" "scrape-catalog" "--ui" "gui"]) :options :ui)))))
 
 (deftest start-app
-  (testing "starting app from a clean state, no dirs, no summary file, nothing"
+  (testing "starting app from a clean state, no dirs, no catalog, nothing"
     (try
       (main/-main "--ui" "cli")
       (finally

--- a/update-test-fixtures.sh
+++ b/update-test-fixtures.sh
@@ -20,6 +20,8 @@ dl "https://www.curseforge.com/wow/addons?filter-sort=name&page=1" "curseforge-a
 # curseforge api
 dl "https://addons-ecs.forgesvc.net/api/v2/addon/327019" "curseforge-api-addon--everyaddon.json"
 cp "test/fixtures/curseforge-api-addon--everyaddon.json" "test/fixtures/curseforge-api-addon--everyotheraddon.json"
+## one search result
+dl "https://addons-ecs.forgesvc.net/api/v2/addon/search?gameId=1&index=0&pageSize=1&searchFilter=&sort=2" "curseforge-api-search--truncated.json"
 
 # wowinterface
 dl "https://wowinterface.com/addons.php" "wowinterface-category-list.html"


### PR DESCRIPTION
* adds support for multiple addon directories
* adds support for selecting the 'game track' for an addon directory

A 'game track' for `wowman` is either 'retail' or 'classic' and 'classic' is an alias for 'vanilla' as Blizzard have mentioned they may do other 'classic' releases (wotlk, I hope ...).