### PR TITLE
database support

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -29,11 +29,17 @@ see CHANGELOG.md for a more formal list of changes by release
 
 ### todo
 
+* bug, we have addons in multiple identical categories. fix this in catalog.clj
+    - see 319346
+    - remove call to set in db-load-catalog
 * download-catalog bug
     - I *think* something or things are trying to read the catalog before it has finished downloading
         - this is causing malformed json errors
     - download the catalog to a temporary name and then move into place
 * investigate switching to an embedded database
+    - compare current speed and code against loading addon category data serially
+        - as opposed to in three blocks (categories, addons, category-addons). We might save some time and code
+    - investigate prepared statements when inserting 
     - replace :installed-addon-list usage internally with database
         - we'll need some way of triggering changes
             - I've done this by updating the state with some stats 

--- a/TODO.md
+++ b/TODO.md
@@ -8,14 +8,9 @@ see CHANGELOG.md for a more formal list of changes by release
 
 ### done
 
-### todo
-
-* download-catalog bug
-    - I *think* something or things are trying to read the catalog before it has finished downloading
-        - this is causing malformed json errors
-    - download the catalog to a temporary name and then move into place
 * investigate switching to an embedded database
     - there is a lot of catalog-wrangling code happening and it's getting obscure
+        - there is new code now but it's less obscure
     - searching for addons is really limited
         - especially now that we have new dimensions
     - db creation could happen in place of catalog generation
@@ -28,9 +23,25 @@ see CHANGELOG.md for a more formal list of changes by release
         - done
     - update tests so we get a fresh db
         - follow per-case/per-test fixture rules
+        - done
     - replace :addon-summary-list usage internally with database
+        - done
+
+### todo
+
+* download-catalog bug
+    - I *think* something or things are trying to read the catalog before it has finished downloading
+        - this is causing malformed json errors
+    - download the catalog to a temporary name and then move into place
+* investigate switching to an embedded database
     - replace :installed-addon-list usage internally with database
         - we'll need some way of triggering changes
+            - I've done this by updating the state with some stats 
+        - need to think a bit more about this one now that :addon-summary-list is happening
+            - should this replace .wowman.json files?
+                - no, because database isn't permanent
+            - what benefits are there to storing the list of installed addons in the database rather than in an array?
+                - we've already discovered it can be painful to re-create arrays and maps
 * bug, 'clear cache' didn't delete the catalog.json
 * user-agent needs to be updated
     - it using a naive (subs ...) call
@@ -44,7 +55,6 @@ see CHANGELOG.md for a more formal list of changes by release
             - fingerprint is 9 digits and all decimal, so not a hex digest
     - wowinterface checksum is hidden behind a javascript tabber but still available
         - wowinterface do have a md5sum in results! score
-
 * short catalog, full catalog
     - the catalog is getting big now and will only get larger
         - curseforge and wowinterface keep accumulating new addons

--- a/TODO.md
+++ b/TODO.md
@@ -10,6 +10,27 @@ see CHANGELOG.md for a more formal list of changes by release
 
 ### todo
 
+* download-catalog bug
+    - I *think* something or things are trying to read the catalog before it has finished downloading
+        - this is causing malformed json errors
+    - download the catalog to a temporary name and then move into place
+* investigate switching to an embedded database
+    - there is a lot of catalog-wrangling code happening and it's getting obscure
+    - searching for addons is really limited
+        - especially now that we have new dimensions
+    - db creation could happen in place of catalog generation
+        - or the database could be created from the catalog
+            - if db is smaller than catalog, this might be a consideration
+        - I think generating the database from the plaintext/json catalog is the most open and flexible
+            - open in that plain text/json is the easiest to inspect/parse/reuse
+            - flexible in that generating an in-memory database on each load avoids database migrations
+                - still need to be careful with changes going forward, but I have been with the catalog so far
+        - done
+    - update tests so we get a fresh db
+        - follow per-case/per-test fixture rules
+    - replace :addon-summary-list usage internally with database
+    - replace :installed-addon-list usage internally with database
+        - we'll need some way of triggering changes
 * bug, 'clear cache' didn't delete the catalog.json
 * user-agent needs to be updated
     - it using a naive (subs ...) call
@@ -23,13 +44,7 @@ see CHANGELOG.md for a more formal list of changes by release
             - fingerprint is 9 digits and all decimal, so not a hex digest
     - wowinterface checksum is hidden behind a javascript tabber but still available
         - wowinterface do have a md5sum in results! score
-* investigate switching to an embedded database
-    - there is a lot of catalog-wrangling code happening and it's getting obscure
-    - searching for addons is really limited
-        - especially now that we have new dimensions
-    - db creation could happen in place of catalog generation
-        - or the database could be created from the catalog
-            - if db is smaller than catalog, this might be a consideration
+
 * short catalog, full catalog
     - the catalog is getting big now and will only get larger
         - curseforge and wowinterface keep accumulating new addons
@@ -57,6 +72,8 @@ see CHANGELOG.md for a more formal list of changes by release
 
 ## todo bucket
 
+* add custom highlighting colours 
+    - I don't mind my colours but not everybody may
 * add ElvUI support. they have json that can be scraped
 * add a 'tabula rasa' option that wipes *everything* 
     - cache, catalog, config, downloaded zip files

--- a/project.clj
+++ b/project.clj
@@ -29,6 +29,9 @@
                  ;; remember to update the LICENCE.txt
                  ;; remember to update pom file (`lein pom`)
 
+                 [com.h2database/h2 "1.4.199"]
+                 [seancorfield/next.jdbc "1.0.6"]
+
                  ]
 
   :profiles {:uberjar {:aot :all}}

--- a/resources/query--all-catalog.sql
+++ b/resources/query--all-catalog.sql
@@ -1,0 +1,16 @@
+SELECT
+  catalog.*,
+  (
+    SELECT
+      group_concat(name separator '|') 
+    FROM
+      category 
+      JOIN
+        addon_category ac 
+        ON category.id = ac.category_id 
+    WHERE
+      ac.addon_source_id = catalog.source_id 
+  )
+  AS category_list 
+FROM
+  catalog

--- a/resources/table--catalog.sql
+++ b/resources/table--catalog.sql
@@ -1,0 +1,18 @@
+create table catalog (
+    source enum('wowinterface', 'curseforge'),
+    source_id int,
+
+    label varchar(255),
+    name varchar(150), -- longest in catalog at time of writing is 49
+    alt_name varchar(150),
+    description varchar(255),
+    uri varchar(255),
+    download_count int,
+    created_date timestamp with time zone,
+    updated_date timestamp with time zone,
+
+    retail_track boolean,
+    vanilla_track boolean,
+    
+    primary key(source_id, source)
+);

--- a/resources/table--catalog.sql
+++ b/resources/table--catalog.sql
@@ -18,5 +18,5 @@ create table if not exists catalog (
     primary key(source_id, source)
 );
 
-create index label_idx on catalog (label);
-create index description_idx on catalog (description);
+create index if not exists label_idx on catalog (label);
+create index if not exists description_idx on catalog (description);

--- a/resources/table--catalog.sql
+++ b/resources/table--catalog.sql
@@ -9,7 +9,6 @@ create table if not exists catalog (
     uri varchar(255),
     download_count int,
     -- created_date timestamp with time zone, -- curseforge only and unused
-    -- updated_date timestamp with time zone, -- nobody can seem to do dates without *fucking them up* somehow
     updated_date varchar(24), -- we have dates with micro second precision 
 
     retail_track boolean,

--- a/resources/table--catalog.sql
+++ b/resources/table--catalog.sql
@@ -1,4 +1,4 @@
-create table catalog (
+create table if not exists catalog (
     source enum('wowinterface', 'curseforge'),
     source_id int,
 
@@ -8,8 +8,9 @@ create table catalog (
     description varchar(255),
     uri varchar(255),
     download_count int,
-    created_date timestamp with time zone,
-    updated_date timestamp with time zone,
+    -- created_date timestamp with time zone, -- curseforge only and unused
+    -- updated_date timestamp with time zone, -- nobody can seem to do dates without *fucking them up* somehow
+    updated_date varchar(24), -- we have dates with micro second precision 
 
     retail_track boolean,
     vanilla_track boolean,

--- a/resources/table--catalog.sql
+++ b/resources/table--catalog.sql
@@ -18,5 +18,5 @@ create table if not exists catalog (
     primary key(source_id, source)
 );
 
-create index if not exists label_idx on catalog (label);
-create index if not exists description_idx on catalog (description);
+create index if not exists idx_label on catalog (label);
+create index if not exists idx_description on catalog (description);

--- a/resources/table--catalog.sql
+++ b/resources/table--catalog.sql
@@ -17,3 +17,6 @@ create table if not exists catalog (
     
     primary key(source_id, source)
 );
+
+create index label_idx on catalog (label);
+create index description_idx on catalog (description);

--- a/resources/table--category.sql
+++ b/resources/table--category.sql
@@ -1,4 +1,4 @@
-create table category (
+create table if not exists category (
     
 
 );

--- a/resources/table--category.sql
+++ b/resources/table--category.sql
@@ -1,0 +1,4 @@
+create table category (
+    
+
+);

--- a/resources/table--category.sql
+++ b/resources/table--category.sql
@@ -1,4 +1,21 @@
+-- all known categories and where they came from
 create table if not exists category (
-    
+    id int auto_increment,
+    name varchar(50),
+    source enum('wowinterface', 'curseforge'),
 
+    primary key(id)
+);
+
+CREATE UNIQUE INDEX if not exists unqidx_name_source ON category(name, source);
+
+-- m:n table of addon<->category
+create table if not exists addon_category (
+    addon_source_id int,
+    addon_source enum('wowinterface', 'curseforge'),
+    category_id int,
+
+    primary key(addon_source, addon_source_id, category_id),
+    foreign key(category_id) references category(id),
+    foreign key(addon_source_id, addon_source) references catalog(source_id, source)
 );

--- a/src/wowman/core.clj
+++ b/src/wowman/core.clj
@@ -180,9 +180,10 @@
   ([uin]
    (let [uin% (str uin "%")
          %uin% (str "%" uin "%")]
-     (db-query (str select-*-catalog "where label ilike ? or description ilike ?")
-               :arg-list [uin% %uin%]
-               :opts {:max-rows (get-state :search-results-cap)}))))
+     (mapv db-coerce-catalog-values
+           (db-query (str select-*-catalog "where label ilike ? or description ilike ?")
+                     :arg-list [uin% %uin%]
+                     :opts {:max-rows (get-state :search-results-cap)})))))
 
 (defn get-db
   "like `get-state`, uses 'paths' (keywords) to do predefined queries"

--- a/src/wowman/core.clj
+++ b/src/wowman/core.clj
@@ -552,6 +552,9 @@
         toc-keys (if (vector? toc-keys) toc-keys [toc-keys])
         sql-arg-vals (mapv #(get installed-addon %) toc-keys) ;; [:source :source-id] => ["curseforge" 12345], [:name] => ["foo"]
 
+        _ (when (some nil? sql-arg-vals)
+            (warn "(debug) failed to find all values for sql query. keys:" toc-keys "vals:" sql-arg-vals))
+
         sql (str select-*-catalog "where " sql-arg-template)
         ;;_ (info sql-arg-vals) ;; there are cases where an arg is nil. should we still query if we don't have all the facts?
         results (db-query sql :arg-list sql-arg-vals)
@@ -601,7 +604,6 @@
           [matched unmatched] (utils/split-filter #(contains? % :final) match-results)
 
           matched (mapv :final matched)
-          unmatched (mapv :installed-addon unmatched)
           unmatched-names (set (map :name unmatched))
 
           expanded-installed-addon-list (into matched unmatched)

--- a/src/wowman/core.clj
+++ b/src/wowman/core.clj
@@ -235,7 +235,7 @@
 
 (defn-spec remove-addon-dir! nil?
   ([]
-   (when-let [addon-dir (get-state :selected-addon-dir)] 
+   (when-let [addon-dir (get-state :selected-addon-dir)]
      (remove-addon-dir! addon-dir)))
   ([addon-dir ::sp/addon-dir]
    (dosync
@@ -515,16 +515,16 @@
 
 ;;
 
+
 (defn db-coerce-row-values
   [row]
   (when row
     (assoc row
      ;;(utils/coerce-row-values {:updated-date str} row)
      ;; these need to be dealt with properly
-     :category-list []
-     :game-track-list [(when (:retail-track row) "retail")
-                       (when (:vanilla-track row) "classic")]
-     )))
+           :category-list []
+           :game-track-list [(when (:retail-track row) "retail")
+                             (when (:vanilla-track row) "classic")])))
 
 (defn find-in-db [installed-addon toc-keys catalog-keys]
   (let [catalog-keys (if (vector? catalog-keys) catalog-keys [catalog-keys]) ;; ["source" "source_id"] => ["source" "source_id"], "name" => ["name"]
@@ -547,11 +547,13 @@
 
 (defn find-first-in-db
   [installed-addon match-on-list]
-  (let [[toc-keys catalog-keys] (first match-on-list)
-        match (find-in-db installed-addon toc-keys catalog-keys)]
-    (if-not match ;; recur
-      (find-first-in-db installed-addon (rest match-on-list))
-      match)))
+  (if (empty? match-on-list) ;; we may have exhausted all possibilities. not finding a match is ok
+    installed-addon
+    (let [[toc-keys catalog-keys] (first match-on-list)
+          match (find-in-db installed-addon toc-keys catalog-keys)]
+      (if-not match ;; recur
+        (find-first-in-db installed-addon (rest match-on-list))
+        match))))
 
 (defn -db-match-installed-addons-with-catalog
   "for each installed addon, search the catalog across multiple joins until a match is found. returns immediately when first match is found"
@@ -604,7 +606,7 @@
   (jdbc/execute! (get-state :db) [(slurp "resources/table--catalog.sql")])
   ;;(info "creating 'category' table")
   ;;(jdbc/execute! ds [(slurp "resources/table--category.sql")])
-  
+
   (swap! state update-in [:cleanup] conj (fn []
                                            (try
                                              (db-query "shutdown")

--- a/src/wowman/core.clj
+++ b/src/wowman/core.clj
@@ -149,10 +149,10 @@
    ;; random list of addons, no preference
    (db-query "select * from catalog order by RAND() limit ?" [(get-state :search-results-cap)]))
   ([uin]
-   (let [uin+ (str uin "%")
-         +uin+ (str "%" uin "%")]
+   (let [uin% (str uin "%")
+         %uin% (str "%" uin "%")]
      (sql/find-by-keys (get-state :db) :catalog ["label ilike ? or description ilike ?"
-                                                 uin+ +uin+]
+                                                 uin% %uin%]
                        {:max-rows (get-state :search-results-cap) ;; used to be 250 but with better searching there is less scrolling
                         :builder-fn as-unqualified-hyphenated-maps}))))
 

--- a/src/wowman/core.clj
+++ b/src/wowman/core.clj
@@ -120,8 +120,7 @@
    :selected-search []
    ;; number of results to display in search results pane.
    ;; used to be 250 but with better searching there is less scrolling
-   :search-results-cap 150
-   })
+   :search-results-cap 150})
 
 (def state (atom nil))
 
@@ -145,7 +144,7 @@
   (jdbc/execute! (get-state :db) (into [query] arg-list)
                  (merge {:builder-fn as-unqualified-hyphenated-maps} opts)))
 
-(def select-*-catalog (slurp "resources/query--all-catalog.sql"))
+(def select-*-catalog (str (slurp "resources/query--all-catalog.sql") " ")) ;; trailing space is important
 
 (defn-spec db-split-category-list vector?
   "converts a pipe-separated list of categories into a vector"
@@ -181,10 +180,9 @@
   ([uin]
    (let [uin% (str uin "%")
          %uin% (str "%" uin "%")]
-     (sql/find-by-keys (get-state :db) :catalog ["label ilike ? or description ilike ?"
-                                                 uin% %uin%]
-                       {:max-rows (get-state :search-results-cap)
-                        :builder-fn as-unqualified-hyphenated-maps}))))
+     (db-query (str select-*-catalog "where label ilike ? or description ilike ?")
+               :arg-list [uin% %uin%]
+               :opts {:max-rows (get-state :search-results-cap)}))))
 
 (defn get-db
   "like `get-state`, uses 'paths' (keywords) to do predefined queries"

--- a/src/wowman/http.clj
+++ b/src/wowman/http.clj
@@ -110,7 +110,8 @@
 
       ;; ... otherwise, we must sing and dance
       (try
-        (debug (or message (format "downloading %s to %s" (fs/base-name uri) output-file)))
+        (when message (info message)) ;; always show the message that was explicitly passed in
+        (debug (format "downloading %s to %s" (fs/base-name uri) output-file))
         (client/with-additional-middleware [client/wrap-lower-case-headers (etag-middleware etag-key)]
           (let [params {:redirect-strategy curse-crap-redirect-strategy
                         :cookie-policy :ignore} ;; completely ignore cookies. doesn't stop HttpComponents warning

--- a/src/wowman/utils.clj
+++ b/src/wowman/utils.clj
@@ -15,6 +15,14 @@
    [java-time :as jt]
    [java-time.format]))
 
+(defn uuid
+  []
+  (.toString (java.util.UUID/randomUUID)))
+
+(defn dissoc-all
+  [m l]
+  (apply dissoc m l))
+
 ;; orphaned, might be useful still?
 (defn-spec file-ext-as-kw (s/or :ok keyword?, :error nil?)
   [path ::sp/file]
@@ -148,9 +156,11 @@
   (subs x 0 (min (count x) max)))
 
 (defn in?
-  [vals]
-  (fn [v]
-    (some #{v} vals)))
+  ([needle haystack]
+   (not (nil? (some #{needle} haystack))))
+  ([haystack]
+   (fn [needle]
+     (in? needle haystack))))
 
 (defn-spec idx map?
   [list-of-maps ::sp/list-of-maps, key keyword?]

--- a/src/wowman/utils.clj
+++ b/src/wowman/utils.clj
@@ -15,9 +15,13 @@
    [java-time :as jt]
    [java-time.format]))
 
-(defn coerce-row-values
-  "given a mapping of {key fn} matching keys in given row will be transformed
-  (coerce-row-values {:foo str} {:foo 123}) => {:foo '123'}"
+(defn shallow-flatten
+  [lst]
+  (mapcat identity lst))
+
+(defn coerce-map-values
+  "given a mapping of {key fn} matching keys in given map will be transformed
+  (coerce-map-values {:foo str} {:foo 123}) => {:foo '123'}"
   [mapping row]
   (let [reducer (fn [ncoll [k v]]
                   (assoc ncoll k

--- a/src/wowman/utils.clj
+++ b/src/wowman/utils.clj
@@ -15,6 +15,18 @@
    [java-time :as jt]
    [java-time.format]))
 
+(defn coerce-row-values
+  "given a mapping of {key fn} matching keys in given row will be transformed
+  (coerce-row-values {:foo str} {:foo 123}) => {:foo '123'}"
+  [mapping row]
+  (let [reducer (fn [ncoll [k v]]
+                  (assoc ncoll k
+                         (if (contains? mapping k)
+                           ((get mapping k) v)
+                           v)))]
+    (reduce reducer {} row)))
+
+
 (defn uuid
   []
   (.toString (java.util.UUID/randomUUID)))

--- a/src/wowman/utils.clj
+++ b/src/wowman/utils.clj
@@ -26,7 +26,6 @@
                            v)))]
     (reduce reducer {} row)))
 
-
 (defn uuid
   []
   (.toString (java.util.UUID/randomUUID)))

--- a/test/wowman/core_test.clj
+++ b/test/wowman/core_test.clj
@@ -225,7 +225,7 @@
           toc (merge toc nfo)
 
           ;; we then attempt to match this 'toc+nfo' to an addon in the catalog
-          catalog-match (core/-match-installed-addons-with-catalog [toc] [catalog])
+          catalog-match (core/-db-match-installed-addons-with-catalog [toc] [catalog])
 
           ;; this is a m:n match and we typically get back heaps of results
           ;; in this case we have a catalog of 1 and are not interested in how the addon was matched (:final)

--- a/test/wowman/core_test.clj
+++ b/test/wowman/core_test.clj
@@ -159,30 +159,46 @@
                 output-path (fixture-path "import--exports.json")
 
                 expected [{:description "Does what no other addon does, slightly differently",
+                           :category-list ["Bags & Inventory"],
                            :update? false,
+                           :updated-date "2019-06-26T01:21:39Z",
                            :group-id "https://www.curseforge.com/wow/addons/everyaddon",
                            :installed-version "v8.2.0-v1.13.2-7135.139",
                            :name "everyaddon",
                            :source "curseforge",
-                           :source-id 1
-                           :interface-version 70000,
-                           :label "EveryAddon 1.2.3",
+                           :interface-version 11300,
+                           :download-uri "https://edge.forgecdn.net/files/1/1/EveryAddon.zip",
+                           :alt-name "everyaddon",
+                           :label "EveryAddon",
+                           :download-count 3000000,
+                           :source-id 1,
+                           :uri "https://www.curseforge.com/wow/addons/everyaddon",
+                           :version "v8.2.0-v1.13.2-7135.139",
                            :dirname "EveryAddon",
-                           :primary? true}
+                           :primary? true,
+                           :matched? true}
+
                           {:description "Does what every addon does, just better",
+                           :category-list ["Professions" "Map & Minimap"],
                            :update? false,
+                           :updated-date "2019-07-03T07:11:47Z",
                            :group-id "https://www.curseforge.com/wow/addons/everyotheraddon",
                            :installed-version "v8.2.0-v1.13.2-7135.139",
                            :name "everyotheraddon",
                            :source "curseforge",
-                           :source-id 2
-                           :interface-version 70000,
-                           :label "EveryOtherAddon 4.5.6",
+                           :interface-version 11300,
+                           :download-uri "https://edge.forgecdn.net/files/2/2/EveryOtherAddon.zip",
+                           :alt-name "everyotheraddon",
+                           :label "Every Other Addon",
+                           :download-count 5400000,
+                           :source-id 2,
+                           :uri "https://www.curseforge.com/wow/addons/everyotheraddon",
+                           :version "v8.2.0-v1.13.2-7135.139",
                            :dirname "EveryOtherAddon",
-                           :primary? true}]]
+                           :primary? true,
+                           :matched? true}]]
 
             (core/import-exported-file output-path)
-            ;; TODO: this refresh isn't able to match the installed addons to the dummy catalog!
             (core/refresh) ;; re-read the installation directory
             (is (= expected (core/get-state :installed-addon-list))))
 

--- a/test/wowman/toc_test.clj
+++ b/test/wowman/toc_test.clj
@@ -77,10 +77,10 @@ SomeAddon.lua")
   (testing "parsing of 'Title' attribute in toc file"
     (let [cases [["Grid" "Grid"] ;; no trailing version? no problems
                  ["Bagnon Void Storage" "Bagnon Void Storage"]
-                 
+
                  ["Grid2" "Grid2"] ;; trailing digit, but not separated by a space
                  ["Bartender4" "Bartender4"]
-                 
+
                  ["Grid 2" "Grid"] ;; trailing digit is removed ...
                  ["WeakAuras 2" "WeakAuras"] ;; ...even when we don't want them to
 


### PR DESCRIPTION
big goals for this feature:

* code removal. I want to cut out loads of code that has grown obscure.
* make the intent of the remaining code *clearer*. 
* make searching addons faster and fuzzier. right now it's a simple "name starts with $userinput" filter. the most basic sql can handle better searching and faster

cons:
* it makes the distributable larger by 3MB
* it's going to touch a *lot* of otherwise stable code
* there is a slight pause of ~2 seconds while the ~10k addons, their categories and the associations are inserted. I have a `todo` in the bucket to start timing these operations to look for regressions and optimisations