### PR TITLE
fixes issue#42

### DIFF
--- a/src/wowman/toc.clj
+++ b/src/wowman/toc.clj
@@ -82,7 +82,7 @@
 (defn-spec rm-trailing-version string?
   "'foo 1.2.3' => 'foo', 'foo 1"
   [str string?]
-  (let [matching-suffix #"[ \d\.]+$"
+  (let [matching-suffix #" v?[\d\.]+$"
         nothing ""]
     (clojure.string/replace str matching-suffix nothing)))
 


### PR DESCRIPTION
'Title' values in .toc files now require a leading space before detecting and stripping trailing version information