### PR TITLE
Big catalog, Little catalog

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -30,9 +30,31 @@ see CHANGELOG.md for a more formal list of changes by release
     - it using a naive (subs ...) call
     - done
         - should handle anything I throw it from now on
+* short catalog, full catalog
+    - investigate how small we can reasonably get the catalog
+        - after removing addons not updated since before beginning of last expac (Legion):
+            - 6555 addons total
+            - 3.1MB file
+        - there are other tricks I could use to cut out some of the fields and just generate them at load time
+            - I think the structure of the catalog will need a more thoughtful revision though
 
 ### todo
 
+* bug,export addon list isn't using selected directory
+* export to markdown
+    - I think I'd like a simple list like:
+        * [addon name](https://source/path/to/addon)
+    - of course, this would be a different type of export than the one used for import
+        - although ... I could possibly parse the list ... and nah.
+* short catalog, full catalog
+    - the catalog is getting big now and will only get larger
+        - curseforge and wowinterface keep accumulating new addons
+        - other sources will come along
+        - database loading operation is already taking a little too long for my liking
+    - a lot of addons could be removed as simply being 'too old'
+        - addons that haven't been updated for two or three releases (6 years) for example
+    - I want to preserve the entirety of the catalog if possible though
+        - perhaps a game setting to opt-in to the larger download
 * bug, we have addons in multiple identical categories. fix this in catalog.clj
     - see 319346
     - remove call to set in db-load-catalog
@@ -53,7 +75,6 @@ see CHANGELOG.md for a more formal list of changes by release
             - what benefits are there to storing the list of installed addons in the database rather than in an array?
                 - we've already discovered it can be painful to re-create arrays and maps
 * bug, 'clear cache' didn't delete the catalog.json
-
 * gui tests are bypassing the path wrangling because the envvar library is using thread-local `binding`
     - change path access to an atom
     - I *think* this may have something to do with a truncated catalog I've encountered now (twice)
@@ -64,17 +85,6 @@ see CHANGELOG.md for a more formal list of changes by release
             - fingerprint is 9 digits and all decimal, so not a hex digest
     - wowinterface checksum is hidden behind a javascript tabber but still available
         - wowinterface do have a md5sum in results! score
-* short catalog, full catalog
-    - the catalog is getting big now and will only get larger
-        - curseforge and wowinterface keep accumulating new addons
-        - other sources will come along
-        - database loading operation is already taking a little too long for my liking
-    - a lot of addons could be removed as simply being 'too old'
-        - addons that haven't been updated for two or three releases (6 years) for example
-    - I want to preserve the entirety of the catalog if possible though
-        - perhaps a game setting to opt-in to the larger download
-    - investigate how small we can reasonably get the catalog
-        - might tie in with creating a database
 * remove 'updating' catalogs
     - a full weekly scrape is good enough
     - this logic has introduced a *lot* of code that can be removed

--- a/TODO.md
+++ b/TODO.md
@@ -68,6 +68,7 @@ see CHANGELOG.md for a more formal list of changes by release
     - the catalog is getting big now and will only get larger
         - curseforge and wowinterface keep accumulating new addons
         - other sources will come along
+        - database loading operation is already taking a little too long for my liking
     - a lot of addons could be removed as simply being 'too old'
         - addons that haven't been updated for two or three releases (6 years) for example
     - I want to preserve the entirety of the catalog if possible though

--- a/TODO.md
+++ b/TODO.md
@@ -123,6 +123,7 @@ see CHANGELOG.md for a more formal list of changes by release
 
 ## todo bucket
 
+* switch catalog loading to load-json-file-safely
 * when adding an addon-dir, if path ends with /_classic_/Interface/Addons, set game track to classic
 * add a sha256 sum to release file
     - will prevent me from having to download release to generate a sumfile

--- a/TODO.md
+++ b/TODO.md
@@ -42,6 +42,14 @@ see CHANGELOG.md for a more formal list of changes by release
 
         - there are other tricks I could use to cut out some of the fields and just generate them at load time
             - I think the structure of the catalog will need a more thoughtful revision though
+        - done
+    - support N catalogs
+        - full, short, curseforge, wowinterface
+            - done
+        - curseforge and wowinterface are proper catalogs
+            - they're missing 'source'
+                - hacked around for now
+            - done
 
 ### todo
 

--- a/TODO.md
+++ b/TODO.md
@@ -53,6 +53,7 @@ see CHANGELOG.md for a more formal list of changes by release
 
 ### todo
 
+* investigate usage of spec-tools/coerce and remove if necessary
 * wowman-data, stop publishing a 'daily' release
     - we have multiple catalogs now
 * remove debugging? mode

--- a/TODO.md
+++ b/TODO.md
@@ -35,11 +35,17 @@ see CHANGELOG.md for a more formal list of changes by release
         - after removing addons not updated since before beginning of last expac (Legion):
             - 6555 addons total
             - 3.1MB file
+            - 1.5 second db load time
+                "Elapsed time: 1.222319 msecs" (categories)
+                "Elapsed time: 483.493881 msecs" (addons)
+                "Elapsed time: 860.562001 msecs" (category->addons)
+
         - there are other tricks I could use to cut out some of the fields and just generate them at load time
             - I think the structure of the catalog will need a more thoughtful revision though
 
 ### todo
 
+* remove debugging? mode
 * bug,export addon list isn't using selected directory
 * export to markdown
     - I think I'd like a simple list like:
@@ -55,6 +61,10 @@ see CHANGELOG.md for a more formal list of changes by release
         - addons that haven't been updated for two or three releases (6 years) for example
     - I want to preserve the entirety of the catalog if possible though
         - perhaps a game setting to opt-in to the larger download
+    - there is another todo about supporting custom catalogs
+        - what about supporting N number of catalogs? 
+            - not concurrently, only one could be selected at a time, at least for now
+            - curseforge, wowinterface, full, short, curseforge-short, wowinterface-short ...
 * bug, we have addons in multiple identical categories. fix this in catalog.clj
     - see 319346
     - remove call to set in db-load-catalog

--- a/TODO.md
+++ b/TODO.md
@@ -53,6 +53,8 @@ see CHANGELOG.md for a more formal list of changes by release
 
 ### todo
 
+* wowman-data, stop publishing a 'daily' release
+    - we have multiple catalogs now
 * remove debugging? mode
 * bug,export addon list isn't using selected directory
 * export to markdown
@@ -120,6 +122,7 @@ see CHANGELOG.md for a more formal list of changes by release
 
 ## todo bucket
 
+* when adding an addon-dir, if path ends with /_classic_/Interface/Addons, set game track to classic
 * add a sha256 sum to release file
     - will prevent me from having to download release to generate a sumfile
 * add custom highlighting colours 

--- a/resources/table--catalog.sql
+++ b/resources/table--catalog.sql
@@ -12,7 +12,7 @@ create table if not exists catalog (
     updated_date varchar(24), -- we have dates with micro second precision 
 
     retail_track boolean,
-    vanilla_track boolean,
+    classic_track boolean,
     
     primary key(source_id, source)
 );

--- a/src/wowman/catalog.clj
+++ b/src/wowman/catalog.clj
@@ -44,9 +44,10 @@
      :total (count addon-list)
      :addon-summary-list addon-list}))
 
-(defn-spec write-catalog-data ::sp/extant-file
-  "formats given catalog data and writes it to given `output-file` as json. returns path to the output file"
-  [output-file ::sp/file, catalog-data map?] ;; todo: spec catalog structure
+;; todo: can this be replaced with a simple 'utils/write-json-file' type fn?
+(defn-spec write-catalog ::sp/extant-file
+  "writes catalog to given `output-file` as json. returns path to the output file"
+  [catalog-data ::sp/catalog, output-file ::sp/file]
   (spit output-file (utils/to-json catalog-data))
   output-file)
 
@@ -162,11 +163,30 @@
 
     (format-catalog-data addon-list created-date updated-date)))
 
-(defn-spec merge-catalogs ::sp/extant-file
-  [output-file ::sp/file, curseforge-catalog ::sp/extant-file, wowinterface-catalog ::sp/extant-file]
+;;(defn-spec shorten-catalog (s/or :ok ::sp/catalog, :problem nil?)
+;;  [full-catalog-path ::sp/extant-file] ;; addon-list at this point has been ordered and doesn't resemble a hashmap anymore
+(defn shorten-catalog
+  [full-catalog-path]
+  (let [{:keys [addon-summary-list datestamp]}
+        (utils/load-json-file-safely
+         full-catalog-path
+         :no-file? #(error (format "catalog '%s' could not be found" full-catalog-path))
+         :bad-data? #(error (format "catalog '%s' is malformed and cannot be parsed" full-catalog-path))
+         :invalid-data? #(error (format "catalog '%s' is incorrectly structured and will not be parsed" full-catalog-path))
+         :data-spec ::sp/catalog)
+
+        unmaintained? (fn [addon]
+                        (let [dtobj (java-time/zoned-date-time (:updated-date addon))
+                              release-of-previous-expansion (utils/todt "2016-08-30T00:00:00Z")]
+                          (java-time/before? dtobj release-of-previous-expansion)))]
+    (when addon-summary-list
+      (format-catalog-data (remove unmaintained? addon-summary-list) datestamp datestamp))))
+
+(defn-spec merge-catalogs ::sp/catalog
+  [curseforge-catalog ::sp/extant-file, wowinterface-catalog ::sp/extant-file]
   (let [aa (utils/load-json-file curseforge-catalog)
         ab (utils/load-json-file wowinterface-catalog)]
-    (write-catalog-data output-file (-merge-catalogs aa ab))))
+    (-merge-catalogs aa ab)))
 
 ;;
 

--- a/src/wowman/catalog.clj
+++ b/src/wowman/catalog.clj
@@ -39,11 +39,11 @@
      :total (count addon-list)
      :addon-summary-list addon-list}))
 
-;; todo: can this be replaced with a simple 'utils/write-json-file' type fn?
 (defn-spec write-catalog ::sp/extant-file
   "writes catalog to given `output-file` as json. returns path to the output file"
-  [catalog-data ::sp/catalog, output-file ::sp/file]
-  (spit output-file (utils/to-json catalog-data))
+  [catalog-data ::sp/catalog, output-file ::sp/file]  ;; addon-list at this point has been ordered and doesn't resemble a hashmap anymore
+  (utils/dump-json-file output-file catalog-data)
+  (info "wrote" output-file)
   output-file)
 
 ;;
@@ -158,10 +158,8 @@
 
     (format-catalog-data addon-list created-date updated-date)))
 
-;;(defn-spec shorten-catalog (s/or :ok ::sp/catalog, :problem nil?)
-;;  [full-catalog-path ::sp/extant-file] ;; addon-list at this point has been ordered and doesn't resemble a hashmap anymore
-(defn shorten-catalog
-  [full-catalog-path]
+(defn-spec shorten-catalog (s/or :ok ::sp/catalog, :problem nil?)
+  [full-catalog-path ::sp/extant-file]
   (let [{:keys [addon-summary-list datestamp]}
         (utils/load-json-file-safely
          full-catalog-path

--- a/src/wowman/core.clj
+++ b/src/wowman/core.clj
@@ -78,8 +78,7 @@
          :selected-catalog :short}
 
    :catalog-source-list [{:name :short :label "Short (default)" :source "https://raw.githubusercontent.com/ogri-la/wowman-data/master/catalog-short.json"}
-                         ;; todo: change the name of the release from 'daily' to something else
-                         {:name :full :label "Full" :source "https://github.com/ogri-la/wowman-data/releases/download/daily/catalog.json"}
+                         {:name :full :label "Full" :source "https://raw.githubusercontent.com/ogri-la/wowman-data/master/catalog.json"}
 
                          {:name :curseforge-catalog-file :label "Curseforge" :source "https://raw.githubusercontent.com/ogri-la/wowman-data/master/curseforge.json"}
                          {:name :wowinterface-catalog-file :label "WoWInterface" :source "https://raw.githubusercontent.com/ogri-la/wowman-data/master/wowinterface.json"}]
@@ -226,8 +225,7 @@
                    (try
                      (callback new-state)
                      (catch Exception e
-                       (error e "error caught in watch! your callback *must* be catching these or the thread dies silently! rethrowing")
-                       (throw e))))))
+                       (error e "error caught in watch! your callback *must* be catching these or the thread dies silently! rethrowing"))))))
 
     (swap! state update-in [:cleanup] conj rmwatch)
     nil))

--- a/src/wowman/core.clj
+++ b/src/wowman/core.clj
@@ -37,10 +37,6 @@
 
 (def colours (utils/nav-map-fn -colour-map))
 
-;; not in `paths` because it's not configurable
-;; deprecated
-(def remote-catalog "https://github.com/ogri-la/wowman-data/releases/download/daily/catalog.json")
-
 (defn paths
   "returns a map of paths whose location may vary depending on the location of the current working directory"
   [& path]
@@ -60,13 +56,6 @@
         cfg-file (join config-dir "config.json") ;; /home/$you/.config/wowman/config.json
         etag-db-file (join data-dir "etag-db.json") ;; /home/$you/.local/share/wowman/etag-db.json
 
-        ;;curseforge-catalog (join data-dir "curseforge.json") ;; /home/$you/.local/share/wowman/cache/curseforge.json
-        ;;curseforge-catalog-updates (join data-dir "curseforge-updates.json") ;; todo: remove this intermediate file
-        ;;wowinterface-catalog (join data-dir "wowinterface.json")
-
-        ;;catalog (join data-dir "catalog.json")
-        ;;catalog-short (join data-dir "catalog-short.json")
-
         ;; ensure path ends with `-file` or `-dir` or `-uri`
         path-map {:config-dir config-dir
                   :data-dir data-dir
@@ -74,15 +63,7 @@
                   :cfg-file cfg-file
                   :etag-db-file etag-db-file
 
-                  :catalog-dir data-dir
-
-                  ;;:catalog-file catalog
-                  ;;:catalog-file-short catalog-short
-
-                  ;;:curseforge-catalog-file curseforge-catalog
-                  ;;:curseforge-catalog-updates-file curseforge-catalog-updates ;; todo, remove
-                  ;;:wowinterface-catalog-file wowinterface-catalog
-                  }]
+                  :catalog-dir data-dir}]
     (nav-map path-map path)))
 
 (def -state-template
@@ -98,7 +79,7 @@
 
    :catalog-source-list [{:name :short :label "Short (default)" :source "https://raw.githubusercontent.com/ogri-la/wowman-data/master/catalog-short.json"}
                          ;; todo: change the name of the release from 'daily' to something else
-                         {:name :full :label "Full" :source remote-catalog}
+                         {:name :full :label "Full" :source "https://github.com/ogri-la/wowman-data/releases/download/daily/catalog.json"}
 
                          {:name :curseforge-catalog-file :label "Curseforge" :source "https://raw.githubusercontent.com/ogri-la/wowman-data/master/curseforge.json"}
                          {:name :wowinterface-catalog-file :label "WoWInterface" :source "https://raw.githubusercontent.com/ogri-la/wowman-data/master/wowinterface.json"}]

--- a/src/wowman/core.clj
+++ b/src/wowman/core.clj
@@ -150,11 +150,11 @@
     (clojure.string/split category-list-str #"\|")))
 
 (defn db-gen-game-track-list
-  "converts the 'retail_track' and 'vanilla_track' boolean values into a list of strings"
+  "converts the 'retail_track' and 'classic_track' boolean values in db into a list of strings"
   [row]
   (let [track-list (vec (remove nil? [(when (:retail-track row) "retail")
-                                      (when (:vanilla-track row) "classic")]))
-        row (dissoc row :retail-track :vanilla-track)]
+                                      (when (:classic-track row) "classic")]))
+        row (dissoc row :retail-track :classic-track)]
     (if (empty? track-list)
       row
       (assoc row :game-track-list track-list))))
@@ -704,7 +704,7 @@
                                      ;;:created-date :created_date ;; curseforge only and unused
                                      :updated-date :updated_date}
                             new {:retail_track (utils/in? "retail" (:game-track-list row))
-                                 :vanilla_track (utils/in? "classic" (:game-track-list row))}
+                                 :classic_track (utils/in? "classic" (:game-track-list row))}
 
                             absent-source {:source (or (:source row) missing-source)}]
                         (-> row (utils/dissoc-all ignored) (rename-keys mapping) (merge new) (merge absent-source))))]

--- a/src/wowman/core.clj
+++ b/src/wowman/core.clj
@@ -525,7 +525,7 @@
 ;; catalog handling
 ;;
 
-(defn-spec get-catalog-source (s/or :ok ::sp/catalog-source, :not-found nil?)
+(defn-spec get-catalog-source (s/or :ok ::sp/catalog-source-map, :not-found nil?)
   ([]
    (get-catalog-source (get-state :cfg :selected-catalog)))
   ([catalog-name keyword?]
@@ -540,7 +540,7 @@
 
 (defn-spec catalog-local-path ::sp/file
   "given a catalog-source map, returns the local path to the catalog."
-  [catalog-source ::sp/catalog-source]
+  [catalog-source ::sp/catalog-source-map]
   ;; {:name :full ...} => "/path/to/catalog/dir/full-catalog.json"
   (utils/join (paths :catalog-dir) (-> catalog-source :name name (str "-catalog.json"))))
 
@@ -679,7 +679,7 @@
     (let [ds (get-state :db)
           catalog-source (get-catalog-source)
           catalog-path (catalog-local-path catalog-source)
-          _ (info "loading catalog")
+          _ (info (format "loading catalog '%s'" (name (get-state :cfg :selected-catalog))))
           _ (debug "loading addon summaries from catalog into database:" catalog-path)
 
           ;; total hack and to be removed once curseforge/wowinterface catalogs have a :source field

--- a/src/wowman/core.clj
+++ b/src/wowman/core.clj
@@ -246,8 +246,7 @@
                      (callback new-state)
                      (catch Exception e
                        (error e "error caught in watch! your callback *must* be catching these or the thread dies silently! rethrowing")
-                       (throw e)
-                     )))))
+                       (throw e))))))
 
     (swap! state update-in [:cleanup] conj rmwatch)
     nil))
@@ -266,34 +265,30 @@
    (not (nil? (some #{addon-dir} (mapv :addon-dir addon-dir-list))))))
 
 (defn-spec add-addon-dir! nil?
-  ([addon-dir ::sp/addon-dir]
-   (add-addon-dir! addon-dir "retail"))
-  ([addon-dir ::sp/addon-dir, game-track ::sp/game-track]
-   (let [stub {:addon-dir addon-dir :game-track game-track}]
-     (when-not (addon-dir-exists? addon-dir)
-       (swap! state update-in [:cfg :addon-dir-list] conj stub))
-     nil)))
+  [addon-dir ::sp/addon-dir, game-track ::sp/game-track]
+  (let [stub {:addon-dir addon-dir :game-track game-track}]
+    (when-not (addon-dir-exists? addon-dir)
+      (swap! state update-in [:cfg :addon-dir-list] conj stub))
+    nil))
 
 (defn-spec set-addon-dir! nil?
   "adds a new :addon-dir to :addon-dir-list (if it doesn't already exist) and marks it as selected"
   [addon-dir ::sp/addon-dir]
   (let [addon-dir (-> addon-dir fs/absolute fs/normalized str)]
-    (dosync
-     (add-addon-dir! addon-dir)
-     (swap! state assoc :selected-addon-dir addon-dir))
-    nil))
+    (add-addon-dir! addon-dir "retail")
+    (swap! state assoc :selected-addon-dir addon-dir))
+  nil)
 
 (defn-spec remove-addon-dir! nil?
   ([]
    (when-let [addon-dir (get-state :selected-addon-dir)]
      (remove-addon-dir! addon-dir)))
   ([addon-dir ::sp/addon-dir]
-   (dosync
-    (let [matching #(= addon-dir (:addon-dir %))
-          new-addon-dir-list (->> (get-state :cfg :addon-dir-list) (remove matching) vec)]
-      (swap! state assoc-in [:cfg :addon-dir-list] new-addon-dir-list)
-      ;; this may be nil if the new addon-dir-list is empty
-      (swap! state assoc :selected-addon-dir (-> new-addon-dir-list first :addon-dir))))
+   (let [matching #(= addon-dir (:addon-dir %))
+         new-addon-dir-list (->> (get-state :cfg :addon-dir-list) (remove matching) vec)]
+     (swap! state assoc-in [:cfg :addon-dir-list] new-addon-dir-list)
+     ;; this may be nil if the new addon-dir-list is empty
+     (swap! state assoc :selected-addon-dir (-> new-addon-dir-list first :addon-dir)))
    nil))
 
 (defn available-addon-dirs

--- a/src/wowman/core.clj
+++ b/src/wowman/core.clj
@@ -567,6 +567,11 @@
   ;; {:name :full ...} => "/path/to/catalog/dir/full-catalog.json"
   (utils/join (paths :catalog-dir) (-> catalog-source :name name (str "-catalog.json"))))
 
+(defn-spec find-catalog-local-path ::sp/file
+  "convenience wrapper around `catalog-local-path`"
+  [catalog-name keyword?]
+  (catalog-local-path (get-catalog-source catalog-name)))
+
 (defn-spec download-catalog (s/or :ok ::sp/extant-file, :error nil?)
   "downloads catalog to expected location, nothing more"
   [& [catalog] (s/* keyword?)]

--- a/src/wowman/core.clj
+++ b/src/wowman/core.clj
@@ -64,6 +64,7 @@
         wowinterface-catalog (join data-dir "wowinterface.json")
 
         catalog (join data-dir "catalog.json")
+        catalog-short (join data-dir "catalog-short.json")
 
         ;; ensure path ends with `-file` or `-dir` or `-uri`
         path-map {:config-dir config-dir
@@ -73,6 +74,7 @@
                   :etag-db-file etag-db-file
 
                   :catalog-file catalog
+                  :catalog-file-short catalog-short
 
                   :curseforge-catalog-file curseforge-catalog
                   :curseforge-catalog-updates-file curseforge-catalog-updates ;; todo, remove

--- a/src/wowman/core.clj
+++ b/src/wowman/core.clj
@@ -80,8 +80,8 @@
    :catalog-source-list [{:name :short :label "Short (default)" :source "https://raw.githubusercontent.com/ogri-la/wowman-data/master/catalog-short.json"}
                          {:name :full :label "Full" :source "https://raw.githubusercontent.com/ogri-la/wowman-data/master/catalog.json"}
 
-                         {:name :curseforge-catalog-file :label "Curseforge" :source "https://raw.githubusercontent.com/ogri-la/wowman-data/master/curseforge.json"}
-                         {:name :wowinterface-catalog-file :label "WoWInterface" :source "https://raw.githubusercontent.com/ogri-la/wowman-data/master/wowinterface.json"}]
+                         {:name :curseforge :label "Curseforge" :source "https://raw.githubusercontent.com/ogri-la/wowman-data/master/curseforge.json"}
+                         {:name :wowinterface :label "WoWInterface" :source "https://raw.githubusercontent.com/ogri-la/wowman-data/master/wowinterface.json"}]
 
    ;; subset of possible data about all INSTALLED addons
    ;; starts as parsed .toc file data
@@ -682,7 +682,7 @@
           _ (debug "loading addon summaries from catalog into database:" catalog-path)
 
           ;; total hack and to be removed once curseforge/wowinterface catalogs have a :source field
-          missing-source (if (= (:name catalog-source) :curseforge-catalog-file)
+          missing-source (if (= (:name catalog-source) :curseforge)
                            "curseforge"
                            "wowinterface")
 

--- a/src/wowman/core.clj
+++ b/src/wowman/core.clj
@@ -321,12 +321,6 @@
   [file-opts map?, cli-opts map?]
   (debug "loading file config:" file-opts)
   (let [default-cfg (:cfg -state-template)
-
-        ;; todo: this sucks,fix
-        file-opts (if (contains? file-opts :selected-catalog)
-                    (update-in file-opts [:selected-catalog] keyword)
-                    file-opts)
-
         cfg (merge default-cfg file-opts)
         cfg (handle-legacy-install-dir cfg)
         ;; doesn't support optional :opt keysets
@@ -364,7 +358,10 @@
    (when-not (fs/exists? (paths :cfg-file))
      (warn "configuration file not found: " (paths :cfg-file)))
 
-   (let [file-opts (utils/load-json-file-safely (paths :cfg-file) :no-file? {} :bad-data? {})
+   (let [file-opts (utils/load-json-file-safely (paths :cfg-file)
+                                                :no-file? {}
+                                                :bad-data? {}
+                                                :transform-map {:selected-catalog keyword})
          cfg (configure file-opts cli-opts)
          etag-db (utils/load-json-file-safely (paths :etag-db-file) :no-file? {} :bad-data? {})
          new-state {:cfg cfg, :cli-opts cli-opts, :file-opts file-opts, :etag-db etag-db

--- a/src/wowman/main.clj
+++ b/src/wowman/main.clj
@@ -67,7 +67,7 @@
 ;;
 
 (def catalog-actions
-  #{:scrape-catalog :update-catalog :merge-catalog
+  #{:scrape-catalog :update-catalog :write-catalog
     :scrape-curseforge-catalog :update-curseforge-catalog
     :scrape-wowinterface-catalog :update-wowinterface-catalog})
 

--- a/src/wowman/main.clj
+++ b/src/wowman/main.clj
@@ -19,7 +19,7 @@
 (Thread/setDefaultUncaughtExceptionHandler
  (reify Thread$UncaughtExceptionHandler
    (uncaughtException [_ thread ex]
-     (error (timbre/stacktrace ex) "Uncaught exception on" (.getName thread)))))
+     (error ex "Uncaught exception on" (.getName thread)))))
 
 (defn stop
   []

--- a/src/wowman/main.clj
+++ b/src/wowman/main.clj
@@ -51,12 +51,15 @@
 (defn test
   [& [path]]
   (clojure.tools.namespace.repl/refresh) ;; reloads all namespaces, including wowman.whatever-test ones
-  (logging/change-log-level :debug)
-  (if path
-    (if (some #{path} [:core :http :main :toc :utils :curseforge :curseforge-api :zip :catalog :cli :gui :wowinterface])
-      (clojure.test/run-all-tests (re-pattern (str "wowman." (name path) "-test")))
-      (error "unknown test file:" path))
-    (clojure.test/run-all-tests #"wowman\..*-test")))
+  (try
+    (logging/change-log-level :debug)
+    (if path
+      (if (some #{path} [:core :http :main :toc :utils :curseforge :curseforge-api :zip :catalog :cli :gui :wowinterface])
+        (clojure.test/run-all-tests (re-pattern (str "wowman." (name path) "-test")))
+        (error "unknown test file:" path))
+      (clojure.test/run-all-tests #"wowman\..*-test"))
+    (finally
+      (logging/change-log-level (:level logging/default-logging-config)))))
 
 ;;
 

--- a/src/wowman/specs.clj
+++ b/src/wowman/specs.clj
@@ -161,4 +161,4 @@
 
 ;;
 
-(s/def ::catalog-source map?)
+(s/def ::catalog-source-map map?)

--- a/src/wowman/specs.clj
+++ b/src/wowman/specs.clj
@@ -120,8 +120,8 @@
 (s/def ::selected? boolean?)
 (s/def ::addon-dir-map (s/keys :req-un [::addon-dir ::game-track]))
 (s/def ::addon-dir-list (s/coll-of ::addon-dir-map))
-(s/def ::user-config (s/keys :req-un [::addon-dir-list
-                                      ::debug?]))
+(s/def ::selected-catalog keyword?)
+(s/def ::user-config (s/keys :req-un [::addon-dir-list ::debug? ::selected-catalog]))
 
 (s/def ::reason-phrase (s/and string? #(<= (count %) 50)))
 (s/def ::status int?) ;; a little too general but ok for now
@@ -156,3 +156,7 @@
 (s/def ::export-record (s/keys :req-un [::name]
                                :opt [::source]))
 (s/def ::export-record-list (s/coll-of ::export-record))
+
+;;
+
+(s/def ::catalog-source map?)

--- a/src/wowman/ui/cli.clj
+++ b/src/wowman/ui/cli.clj
@@ -25,7 +25,7 @@
 (defmethod action :scrape-wowinterface-catalog
   [_]
   (binding [http/*cache* (core/cache)]
-    (wowinterface/scrape (paths :wowinterface-catalog-file))))
+    (wowinterface/scrape (core/find-catalog-local-path :wowinterface-catalog-file))))
 
 (defmethod action :update-wowinterface-catalog
   [_]
@@ -37,8 +37,7 @@
   [_]
   ;; todo: move to core.clj
   (binding [http/*cache* (core/cache)]
-    ;;(curseforge/download-all-addon-summaries (paths :curseforge-catalog-file))
-    (let [output-file (paths :curseforge-catalog-file)
+    (let [output-file (core/find-catalog-local-path :curseforge-catalog-file)
           catalog-data (curseforge-api/download-all-summaries-alphabetically)
           created (utils/datestamp-now-ymd)
           updated created
@@ -60,14 +59,14 @@
 (defmethod action :write-catalog
   [_]
     ;; writes the 'full' and 'short' catalog files by combining the individual host catalogs
-  (let [curseforge-catalog (paths :curseforge-catalog-file)
-        wowinterface-catalog (paths :wowinterface-catalog-file)
+  (let [curseforge-catalog (core/find-catalog-local-path :curseforge-catalog-file)
+        wowinterface-catalog (core/find-catalog-local-path :wowinterface-catalog-file)
         catalog (catalog/merge-catalogs curseforge-catalog wowinterface-catalog)]
     (-> catalog
-        (catalog/write-catalog (paths :catalog-file))
+        (catalog/write-catalog (core/find-catalog-local-path :full))
 
         catalog/shorten-catalog
-        (catalog/write-catalog (paths :catalog-file-short)))))
+        (catalog/write-catalog (core/find-catalog-local-path :short)))))
 
 (defmethod action :scrape-catalog
   [_]

--- a/src/wowman/ui/gui.clj
+++ b/src/wowman/ui/gui.clj
@@ -100,7 +100,7 @@
       (f)
       (catch RuntimeException re
         (error re "unhandled exception in thread")))))
-  
+
 (defn async-handler
   "like `handler`, but each function is executed on a separate thread instead of sequentially"
   [& fl]

--- a/src/wowman/ui/gui.clj
+++ b/src/wowman/ui/gui.clj
@@ -691,7 +691,9 @@
     (sb/bind (sb/selection catalog-button-grp)
              (sb/b-do* (fn [val]
                          (when val ;; hrm, we're getting two events here, one where the value is nil ...
-                           (async #(core/set-catalog-source! (-> val ss/user-data :name)))))))
+                           (async (fn []
+                                    (core/set-catalog-source! (-> val ss/user-data :name))
+                                    (core/save-settings)))))))
 
     ;; application state updates menu selection
     (core/state-bind [:cfg :selected-catalog]

--- a/src/wowman/ui/gui.clj
+++ b/src/wowman/ui/gui.clj
@@ -674,11 +674,17 @@
                          :items [[root "height 100%, width 100%:100%:100%"]])
                :on-close (if (utils/in-repl?) :dispose :exit)) ;; exit app entirely when not in repl
 
-        file-menu (items
-                   (ss/action :name "Installed" :key "menu I" :mnemonic "i" :handler (switch-tab-handler INSTALLED-TAB))
+        file-menu [(ss/action :name "Installed" :key "menu I" :mnemonic "i" :handler (switch-tab-handler INSTALLED-TAB))
                    (ss/action :name "Search" :key "menu H" :mnemonic "h" :handler (switch-tab-handler SEARCH-TAB))
                    :separator
-                   (ss/action :name "Exit" :key "menu Q" :mnemonic "x" :handler (handler #(ss/dispose! newui))))
+                   (ss/action :name "Exit" :key "menu Q" :mnemonic "x" :handler (handler #(ss/dispose! newui)))]
+
+        catalog-button-grp (ss/button-group)
+        catalog-menu (mapv (fn [catalog-source]
+                             (ss/radio-menu-item :id (-> catalog-source :name name (str "catalog-menu-") keyword)
+                                                 :text (:label catalog-source)
+                                                 :group catalog-button-grp))
+                           (core/get-state :catalog-source-list))
 
         addon-menu [(ss/action :name "Update all" :key "menu U" :mnemonic "u" :handler (async-handler core/install-update-all))
                     (ss/action :name "Re-install all" :handler (async-handler core/re-install-all))
@@ -697,7 +703,9 @@
 
         help-menu [(ss/action :name "About wowman" :handler (handler about-wowman-dialog))]
 
-        menu (ss/menubar :items [(ss/menu :text "File" :mnemonic "F" :items file-menu)
+        menu (ss/menubar :id :main-menu
+                         :items [(ss/menu :text "File" :mnemonic "F" :items file-menu)
+                                 (ss/menu :text "Catalog" :items catalog-menu)
                                  (ss/menu :text "Addons" :mnemonic "A" :items addon-menu)
                                  (ss/menu :text "Import/Export" :mnemonic "i" :items impexp-menu)
                                  (ss/menu :text "Cache" :items cache-menu)

--- a/src/wowman/ui/gui.clj
+++ b/src/wowman/ui/gui.clj
@@ -32,9 +32,9 @@
     (ss/select ui (vec path))
     (throw (RuntimeException. "attempted to access an uninitialised GUI"))))
 
-(defn as-selector
+(defn-spec as-selector keyword?
   "converts a regular :keyword to a seesaw selector :#keyword"
-  [kw]
+  [kw keyword?]
   (->> kw name (str "#") keyword))
 
 (def INSTALLED-TAB 0)

--- a/src/wowman/ui/gui.clj
+++ b/src/wowman/ui/gui.clj
@@ -20,6 +20,7 @@
     [swingx :as x]
     [core :as ss]
     [font :refer [font]]
+    [bind :as sb]
     [table :as sstbl]]
    [clojure.spec.alpha :as s]
    [orchestra.core :refer [defn-spec]]
@@ -30,6 +31,11 @@
   (if-let [ui (get-state :gui)]
     (ss/select ui (vec path))
     (throw (RuntimeException. "attempted to access an uninitialised GUI"))))
+
+(defn as-selector
+  "converts a regular :keyword to a seesaw selector :#keyword"
+  [kw]
+  (->> kw name (str "#") keyword))
 
 (def INSTALLED-TAB 0)
 (def SEARCH-TAB 1)
@@ -87,16 +93,20 @@
     (doseq [f fn-list]
       (f))))
 
+(defn async
+  [f]
+  (future
+    (try
+      (f)
+      (catch RuntimeException re
+        (error re "unhandled exception in thread")))))
+  
 (defn async-handler
-  "like `handler`, but each function is executed inside a `go` block instead of sequentially"
+  "like `handler`, but each function is executed on a separate thread instead of sequentially"
   [& fl]
   (fn [_]
     (doseq [f fl]
-      (future
-        (try
-          (f)
-          (catch Exception e
-            (error (timbre/stacktrace e) "unhandled exception in thread")))))))
+      (async f))))
 
 (defn selected-rows-handler
   "calls given `f` with last event when selection has stopped adjusting"
@@ -663,6 +673,35 @@
     (core/import-exported-file path)
     (core/refresh)))
 
+(defn build-catalog-menu
+  []
+  (let [catalog-to-id (fn [catalog]
+                        (-> catalog :name name (str "catalog-menu-") keyword))
+
+        catalog-button-grp (ss/button-group)
+        catalog-menu (mapv (fn [catalog-source]
+                             (ss/radio-menu-item :id (catalog-to-id catalog-source)
+                                                 :text (:label catalog-source)
+                                                 :user-data catalog-source
+                                                 :group catalog-button-grp
+                                                 :selected? (= (core/get-state :cfg :selected-catalog) (:name catalog-source))))
+                           (core/get-state :catalog-source-list))]
+
+    ;; user selection updates application state
+    (sb/bind (sb/selection catalog-button-grp)
+             (sb/b-do* (fn [val]
+                         (when val ;; hrm, we're getting two events here, one where the value is nil ...
+                           (async #(core/set-catalog-source! (-> val ss/user-data :name)))))))
+
+    ;; application state updates menu selection
+    (core/state-bind [:cfg :selected-catalog]
+                     (fn [state]
+                       (let [catalog-source (core/get-catalog-source (-> state :cfg :selected-catalog))
+                             button (-> catalog-source catalog-to-id as-selector select-ui)]
+                         (ss/selection! catalog-button-grp button))))
+
+    catalog-menu))
+
 (defn start-ui
   []
   (let [root->splitter (ss/top-bottom-split (mk-tabber) (notice-logger))
@@ -684,17 +723,15 @@
                    :separator
                    (ss/action :name "Exit" :key "menu Q" :mnemonic "x" :handler (handler #(ss/dispose! newui)))]
 
-        catalog-button-grp (ss/button-group)
-        catalog-menu (mapv (fn [catalog-source]
-                             (ss/radio-menu-item :id (-> catalog-source :name name (str "catalog-menu-") keyword)
-                                                 :text (:label catalog-source)
-                                                 :group catalog-button-grp))
-                           (core/get-state :catalog-source-list))
+        catalog-menu (build-catalog-menu)
 
         addon-menu [(ss/action :name "Update all" :key "menu U" :mnemonic "u" :handler (async-handler core/install-update-all))
                     (ss/action :name "Re-install all" :handler (async-handler core/re-install-all))
                     :separator
                     (ss/action :name "Remove directory" :handler (async-handler core/remove-addon-dir!))]
+
+        impexp-menu [(ss/action :name "Export addon list" :handler (async-handler export-addon-list-handler))
+                     (ss/action :name "Import addon list" :handler (async-handler import-addon-list-handler))]
 
         cache-menu [(ss/action :name "Clear cache" :handler (async-handler core/delete-cache))
                     (ss/action :name "Clear addon zips" :handler (async-handler core/delete-downloaded-addon-zips))
@@ -702,9 +739,6 @@
                     :separator
                     (ss/action :name "Delete WowMatrix.dat files" :handler (async-handler core/delete-wowmatrix-dat-files))
                     (ss/action :name "Delete .wowman.json files" :handler (async-handler (comp core/refresh core/delete-wowman-json-files)))]
-
-        impexp-menu [(ss/action :name "Export addon list" :handler (async-handler export-addon-list-handler))
-                     (ss/action :name "Import addon list" :handler (async-handler import-addon-list-handler))]
 
         help-menu [(ss/action :name "About wowman" :handler (handler about-wowman-dialog))]
 

--- a/test/wowman/cli_test.clj
+++ b/test/wowman/cli_test.clj
@@ -6,7 +6,6 @@
    [wowman.ui.cli :as cli]
    [wowman
     [main :as main]
-    [core :as core]
     [utils :as utils :refer [join]]]
    [me.raynes.fs :as fs :refer [with-cwd]]
    [taoensso.timbre :as log :refer [debug info warn error spy]]))

--- a/test/wowman/cli_test.clj
+++ b/test/wowman/cli_test.clj
@@ -16,9 +16,9 @@
   [f]
   (let [temp-dir-path (fs/temp-dir "wowman.main-test.")
         fake-routes {;; catalog
-                     core/remote-catalog
                      ;; return dummy data. we can do this because the catalog isn't loaded/parsed/validated
                      ;; until the UI (gui or cli) tells it to via a later call to `refresh`
+                     "https://raw.githubusercontent.com/ogri-la/wowman-data/master/catalog-short.json"
                      {:get (fn [req] {:status 200 :body "{}"})}
 
                      ;; latest wowman version

--- a/test/wowman/core_test.clj
+++ b/test/wowman/core_test.clj
@@ -133,7 +133,7 @@
           addon-summary-list (utils/load-json-file (fixture-path "import--dummy-catalog.json"))
 
           fake-routes {;; catalog
-                       "https://github.com/ogri-la/wowman-data/releases/download/daily/catalog.json"
+                       "https://raw.githubusercontent.com/ogri-la/wowman-data/master/catalog-short.json"
                        {:get (fn [req] {:status 200 :body (utils/to-json {:addon-summary-list addon-summary-list})})}
 
                        ;; every-addon
@@ -228,7 +228,7 @@
           alt-api-result (assoc-in api-result [:latestFiles 0 :displayName] "v8.20.00")
 
           fake-routes {;; catalog
-                       "https://github.com/ogri-la/wowman-data/releases/download/daily/catalog.json"
+                       "https://raw.githubusercontent.com/ogri-la/wowman-data/master/catalog-short.json"
                        {:get (fn [req] {:status 200 :body (utils/to-json {:addon-summary-list [catalog]})})}
 
                        ;; every-addon

--- a/test/wowman/core_test.clj
+++ b/test/wowman/core_test.clj
@@ -49,7 +49,7 @@
 
       ;; big long stateful test
 
-      (testing "add-addon-dir!"
+      (testing "add-addon-dir! adds an addon dir with a default game track of 'retail'"
         (core/add-addon-dir! dir1 "retail")
         (is (= [{:addon-dir dir1 :game-track "retail"}] (core/get-state :cfg :addon-dir-list))))
 
@@ -373,7 +373,7 @@
                  [{:retail-track false, :vanilla-track true} {:game-track-list ["classic"]}]
                  [{:retail-track false, :vanilla-track false} {}]
 
-                 ;; order is predictable
+                 ;; order is deterministic
                  [{:vanilla-track true, :retail-track true} {:game-track-list ["retail" "classic"]}]]]
       (doseq [[given expected] cases]
         (is (= expected (core/db-gen-game-track-list given)))))))

--- a/test/wowman/core_test.clj
+++ b/test/wowman/core_test.clj
@@ -110,7 +110,7 @@
 
       (testing "core/get-catalog-source returns the requested catalog if found"
         (is (= short-catalog (core/get-catalog-source :short))))
-      
+
       (testing "core/get-catalog-source, without args, returns the currently selected catalog"
         (is (= short-catalog (core/get-catalog-source))))
 
@@ -120,7 +120,7 @@
       (testing "core/set-catalog-source! always returns nil, even when it successfully completes"
         (is (= nil (core/set-catalog-source! :foo)))
         (is (= short-catalog (core/get-catalog-source)))
-        
+
         (is (= nil (core/set-catalog-source! :full)))
         (is (= full-catalog (core/get-catalog-source))))
 

--- a/test/wowman/core_test.clj
+++ b/test/wowman/core_test.clj
@@ -404,13 +404,13 @@
   (testing "game track fields are turned back into a list"
     (let [cases [[{} {}]
                  [{:retail-track true} {:game-track-list ["retail"]}]
-                 [{:vanilla-track true} {:game-track-list ["classic"]}]
-                 [{:retail-track true, :vanilla-track true} {:game-track-list ["retail" "classic"]}]
-                 [{:retail-track false, :vanilla-track true} {:game-track-list ["classic"]}]
-                 [{:retail-track false, :vanilla-track false} {}]
+                 [{:classic-track true} {:game-track-list ["classic"]}]
+                 [{:retail-track true, :classic-track true} {:game-track-list ["retail" "classic"]}]
+                 [{:retail-track false, :classic-track true} {:game-track-list ["classic"]}]
+                 [{:retail-track false, :classic-track false} {}]
 
                  ;; order is deterministic
-                 [{:vanilla-track true, :retail-track true} {:game-track-list ["retail" "classic"]}]]]
+                 [{:classic-track true, :retail-track true} {:game-track-list ["retail" "classic"]}]]]
       (doseq [[given expected] cases]
         (is (= expected (core/db-gen-game-track-list given)))))))
 

--- a/test/wowman/gui_test.clj
+++ b/test/wowman/gui_test.clj
@@ -33,3 +33,9 @@
   (testing "shameless coverage bump for all the stateless parts in gui"
     (is (= nil (gui/donothing "event object")))
     (is (= nil ((gui/handler (constantly :foo) (constantly :bar)) "event object")))))
+
+(deftest as-selector
+  (testing "a keyword is transformed into a selector as expected"
+    (let [cases [[:foo :#foo]]]
+      (doseq [[given expected] cases]
+        (is (= expected (gui/as-selector given)))))))

--- a/test/wowman/main_test.clj
+++ b/test/wowman/main_test.clj
@@ -6,7 +6,6 @@
    [me.raynes.fs :as fs :refer [with-cwd]]
    [clj-http.fake :refer [with-fake-routes-in-isolation]]
    [wowman
-    [core :as core]
     [utils :refer [join]]
     [main :as main]]))
 

--- a/test/wowman/main_test.clj
+++ b/test/wowman/main_test.clj
@@ -15,9 +15,9 @@
   [f]
   (let [temp-dir-path (fs/temp-dir "wowman.main-test.")
         fake-routes {;; catalog
-                     core/remote-catalog
                      ;; return dummy data. we can do this because the catalog isn't loaded/parsed/validated
                      ;; until the UI (gui or cli) tells it to via a later call to `refresh`
+                     "https://raw.githubusercontent.com/ogri-la/wowman-data/master/catalog-short.json"
                      {:get (fn [req] {:status 200 :body "{}"})}
 
                      ;; latest wowman version

--- a/test/wowman/test_helper.clj
+++ b/test/wowman/test_helper.clj
@@ -9,6 +9,10 @@
 
 (def fixture-dir (-> "test/fixtures" fs/absolute fs/normalized str))
 
+(def data-dir "data")
+
+(def config-dir "config")
+
 (defn fixture-path
   [filename]
   (join fixture-dir filename))
@@ -30,13 +34,16 @@
                      "https://raw.githubusercontent.com/ogri-la/wowman-data/master/catalog-short.json"
                      {:get (fn [req] {:status 200 :body "{}"})}
 
+                     "https://raw.githubusercontent.com/ogri-la/wowman-data/master/catalog.json"
+                     {:get (fn [req] {:status 200 :body "{}"})}
+
                      ;; latest wowman version
                      "https://api.github.com/repos/ogri-la/wowman/releases/latest"
                      {:get (fn [req] {:status 200 :body "{\"tag_name\": \"0.0.0\"}"})}}]
     (try
       (with-fake-routes-in-isolation fake-routes
-        (with-env [:xdg-data-home (join temp-dir-path "data")
-                   :xdg-config-home (join temp-dir-path "config")]
+        (with-env [:xdg-data-home (join temp-dir-path data-dir)
+                   :xdg-config-home (join temp-dir-path config-dir)]
           (with-cwd temp-dir-path
             (debug "created temp working directory" fs/*cwd*)
             (f))))

--- a/test/wowman/test_helper.clj
+++ b/test/wowman/test_helper.clj
@@ -5,7 +5,6 @@
    [me.raynes.fs :as fs :refer [with-cwd]]
    [clj-http.fake :refer [with-fake-routes-in-isolation]]
    [wowman
-    [core :as core]
     [utils :refer [join]]]))
 
 (def fixture-dir (-> "test/fixtures" fs/absolute fs/normalized str))

--- a/test/wowman/test_helper.clj
+++ b/test/wowman/test_helper.clj
@@ -26,9 +26,9 @@
   [f]
   (let [temp-dir-path (fs/temp-dir "wowman.main-test.")
         fake-routes {;; catalog
-                     core/remote-catalog
                      ;; return dummy data. we can do this because the catalog isn't loaded/parsed/validated
                      ;; until the UI (gui or cli) tells it to via a later call to `refresh`
+                     "https://raw.githubusercontent.com/ogri-la/wowman-data/master/catalog-short.json"
                      {:get (fn [req] {:status 200 :body "{}"})}
 
                      ;; latest wowman version


### PR DESCRIPTION
This feature is an effort to reduce the default size of the catalog. 

* catalog is getting [large](https://github.com/ogri-la/wowman-data/releases) (at 5.42MB) as the different hosts add more addons and as I derive more fields to use (like `game-track-list` and `age` and `alt-name`). 
* It takes a few seconds to load all of these addons into the database when wowman is first started
* about half of this data are addons that haven't been updated in a long time and have a good chance of not working anymore.
* I don't want to remove the ability to use the full catalog if you really want to