### PR TITLE
Fix: selecting a non-directory in the addon-dir picker now displays an alert

### DIFF
--- a/src/wowman/ui/gui.clj
+++ b/src/wowman/ui/gui.clj
@@ -1,5 +1,6 @@
 (ns wowman.ui.gui
   (:require
+   [me.raynes.fs :as fs]
    [wowman
     [core :as core :refer [get-state state-bind colours]]
     [logging :as logging]
@@ -236,8 +237,11 @@
   []
   (let [picker (fn []
                  (when-let [dir (chooser/choose-file :type "select" :selection-mode :dirs-only)]
-                   (core/set-addon-dir! (str dir))
-                   (core/save-settings)))
+                   (if (fs/directory? dir)
+                     (do
+                       (core/set-addon-dir! (str dir))
+                       (core/save-settings))
+                     (ss/alert (format "Directory doesn't exist: %s" (str dir))))))
         ;; important! release the event thread using async-handler else updates during process won't be shown until complete
         refresh-button (button "Refresh" (async-handler core/refresh))
         update-all-button (button "Update all" (async-handler core/install-update-all))


### PR DESCRIPTION
Fixes case where entering a non-directory path (or just plain gibberish) in the addon-dir file picker causes a validation error further down than in should. It now displays an alert with the bad path that was chosen.

This is a nicer failure and may help Mac users whose file picker is behaving slightly differently than on Linux.