### PR TITLE
gui, addon-dir dialog changed to :open from "select" for mac users

### DIFF
--- a/src/wowman/ui/gui.clj
+++ b/src/wowman/ui/gui.clj
@@ -236,7 +236,8 @@
 (defn configure-app-panel
   []
   (let [picker (fn []
-                 (when-let [dir (chooser/choose-file :type "select" :selection-mode :dirs-only)]
+                 (when-let [dir (chooser/choose-file :type :open ;; ':open' forces a better dialog type in mac for opening directories
+                                                     :selection-mode :dirs-only)]
                    (if (fs/directory? dir)
                      (do
                        (core/set-addon-dir! (str dir))


### PR DESCRIPTION
':open' appears to force a different type of dialog that is better for selecting directories.
linux behaviour appears unchanged.