### PR TITLE
makes scraping .toc files a little safer

### DIFF
--- a/src/wowman/core.clj
+++ b/src/wowman/core.clj
@@ -194,7 +194,7 @@
 
 (defn-spec remove-addon-dir! nil?
   ([]
-   (when-let [addon-dir (get-state :selected-addon-dir)] 
+   (when-let [addon-dir (get-state :selected-addon-dir)]
      (remove-addon-dir! addon-dir)))
   ([addon-dir ::sp/addon-dir]
    (dosync

--- a/src/wowman/toc.clj
+++ b/src/wowman/toc.clj
@@ -54,10 +54,10 @@
         toc-bname (str (fs/base-name addon))
 
         ;; the ideal, perfect case
-        toc-file (clojure.java.io/file toc-dir (str toc-bname ".toc")) ;; /foo/Addon/Addon.toc
+        toc-file (utils/join toc-dir (str toc-bname ".toc")) ;; /foo/Addon/Addon.toc
 
         ;; less than ideal, probably case-insensitive filesystem + lazy dev
-        alt-toc-file (clojure.java.io/file toc-dir (-> toc-bname lower-case (str ".toc"))) ;; /foo/Addon/addon.toc
+        alt-toc-file (utils/join toc-dir (-> toc-bname lower-case (str ".toc"))) ;; /foo/Addon/addon.toc
 
         ;; fubar case, toc file doesn't match dir
         any-toc-file (first (filter #(-> % lower-case (ends-with? ".toc")) (fs/list-dir toc-dir)))
@@ -67,12 +67,12 @@
                         (debug warning))
                       (-> toc-file utils/de-bom-slurp -read-toc-file))]
     (cond
-      (.exists toc-file) (do-toc-file toc-file)
+      (fs/file? toc-file) (do-toc-file toc-file)
 
       ;; Archaelogy Helper
-      (.exists alt-toc-file) (do-toc-file
-                              alt-toc-file
-                              (format "expecting '%s', found '%s'. filename should be case sensitive" toc-file alt-toc-file))
+      (fs/file? alt-toc-file) (do-toc-file
+                               alt-toc-file
+                               (format "expecting '%s', found '%s'. filename should be case sensitive" toc-file alt-toc-file))
 
       ;; TradeSkillMaster_AuctioningScanSummary
       (not (nil? any-toc-file)) (do-toc-file
@@ -98,40 +98,63 @@
   ;; todo, replace this with a slugify fn
   (-> label lower-case rm-trailing-version (replace ":" "") (replace " " "-") (replace "\\?" "")))
 
-;; TODO: test this nil? error
-(defn-spec parse-addon-toc (s/or :ok ::sp/toc, :error nil?)
+(defn-spec parse-addon-toc ::sp/toc
+  [addon-dir ::sp/extant-dir, keyvals map?]
+  (let [;;decoded-title (:title keyvals) ;; TODO: title may be encoded: https://wow.gamepedia.com/UI_escape_sequences
+        dirname (fs/base-name addon-dir) ;; /foo/bar/baz => baz
+        install-dir (str (fs/parent addon-dir)) ;; /foo/bar/baz => /foo/bar
+        nfo-contents (nfo/read-nfo install-dir dirname)
+
+        ;; doesn't appear to mess with catalog matching
+        ;; if a match in the catalog is found, then that title will be used
+        no-label-label (str dirname " *") ;; "EveryAddon *"
+        label (:title keyvals)
+        label (if-not (empty? label) label no-label-label)
+        _ (when (= label no-label-label)
+            (warn "addon with no \"Title\" value found:" addon-dir))
+
+        ;; if :title is present in list of aliases, add that alias to what we return
+        alias (when (contains? aliases label)
+                {:alias (get aliases label)})
+
+        default-interface-version 80200
+
+        addon {:name (normalise-name label)
+               :dirname dirname
+               :label label
+               :description (or (:notes keyvals) (:description keyvals)) ;; :notes is preferred but we'll fall back to :description
+               :interface-version (or (some-> keyvals :interface utils/to-int)
+                                      default-interface-version)
+               :installed-version (:version keyvals)
+
+               ;; toc file dependency values describe *load order*, not *packaging*
+               ;;:dependencies (:dependencies keyvals)
+               ;;:optional-dependencies (:optionaldependencies keyvals)
+               ;;:required-dependencies (:requireddeps keyvals)
+               }]
+    (merge alias addon nfo-contents)))
+
+(defn-spec parse-addon-toc-guard (s/or :ok ::sp/toc, :error nil?)
+  "wraps the `parse-addon-toc` function and ensures no unhandled exceptions cause a cascading failure"
   [addon-dir ::sp/extant-dir]
-  (if-let [keyvals (read-addon-dir addon-dir)]
-    (let [;;decoded-title (:title keyvals) ;; TODO: title may be encoded: https://wow.gamepedia.com/UI_escape_sequences
-          dirname (fs/base-name addon-dir) ;; /foo/bar/baz => baz
-          install-dir (str (fs/parent addon-dir)) ;; /foo/bar/baz => /foo/bar
-          nfo-contents (nfo/read-nfo install-dir dirname)
-          label (:title keyvals)
-          alias (when (contains? aliases label) ;; ensure :alias is absent if not present
-                  {:alias (get aliases label)})
-          addon {:name (normalise-name (:title keyvals))
-                 :dirname dirname
-                 :label label
-                 :description (or (:notes keyvals) (:description keyvals)) ;; :notes is preferred but we'll fall back to :description
-                 :interface-version (-> keyvals :interface utils/to-int)
-                 :installed-version (:version keyvals)
-
-                 ;; toc file dependency values describe *load order*, not *packaging*
-                 ;;:dependencies (:dependencies keyvals)
-                 ;;:optional-dependencies (:optionaldependencies keyvals)
-                 ;;:required-dependencies (:requireddeps keyvals)
-                 }]
-      (merge alias addon nfo-contents))
-
-    ;; ignore failures to parse Blizzard addons
-    (when-not (.startsWith (fs/base-name addon-dir) "Blizzard_")
-      (warn "failed to find .toc file:" addon-dir))))
+  (try
+    (if-let [keyvals (read-addon-dir addon-dir)]
+      ;; we found a .toc file, now parse it
+      (parse-addon-toc addon-dir keyvals)
+      ;; we didn't find a .toc file, but just ignore it if it looks like an official addon dir
+      (when-not (.startsWith (fs/base-name addon-dir) "Blizzard_")
+        ;; we didn't find a .toc file and it really should have one. warn the user
+        (warn "failed to find .toc file:" addon-dir)))
+    (catch Exception e
+      ;; this addon really messed us up. don't propagate the failure, just report it and return nil
+      (error "please report this! https://github.com/ogri-la/wowman/issues")
+      (error e (format "unhandled error parsing addon in directory '%s': %s" addon-dir (.getMessage e))))))
 
 ;; TODO: test this nil? error
 (defn-spec installed-addons (s/or :ok ::sp/toc-list, :error nil?)
   [addons-dir ::sp/extant-dir]
   (let [addon-dir-list (filter fs/directory? (fs/list-dir addons-dir))
-        addon-list (remove nil? (mapv (comp parse-addon-toc str) addon-dir-list))
+        addon-list (remove nil? (mapv (comp parse-addon-toc-guard str) addon-dir-list))
 
         ;; an addon may actually be many addons bundled together in a single download
         ;; wowman tags the bundled addons as they are unzipped and tries to determine the primary one

--- a/test/wowman/toc_test.clj
+++ b/test/wowman/toc_test.clj
@@ -88,10 +88,10 @@ SomeAddon.lua")
   (testing "parsing of 'Title' attribute in toc file"
     (let [cases [["Grid" "Grid"] ;; no trailing version? no problems
                  ["Bagnon Void Storage" "Bagnon Void Storage"]
-                 
+
                  ["Grid2" "Grid2"] ;; trailing digit, but not separated by a space
                  ["Bartender4" "Bartender4"]
-                 
+
                  ["Grid 2" "Grid"] ;; trailing digit is removed ...
                  ["WeakAuras 2" "WeakAuras"] ;; ...even when we don't want them to
 


### PR DESCRIPTION
* adds a guard around toc/parse-addon-toc to prevent any failure in parsing from affecting the running of the program
* missing 'Title' values in .toc files are now replaced with the name of the addon dir with an asterisk