### PR TITLE
Issue 47 (again)

### DIFF
--- a/src/wowman/core.clj
+++ b/src/wowman/core.clj
@@ -777,7 +777,12 @@
 (defn -re-installable?
   "an addon can only be re-installed if it's been matched to an addon in the catalog"
   [rows]
-  (filterv :uri rows)) ;; :uri is only present in addons that have a match
+  ;; no longer true in 0.9.0. an addon may be found in the catalog but may not match the selected game track
+  ;;(filterv :uri rows)) ;; :uri is only present in addons that have a match
+
+  ;; todo: this indirect logic smells. something like this should be done instead:
+  ;; (filterv (comp :release-available? :matched?) rows)
+  (filterv :download-uri rows))
 
 (defn re-install-selected
   []

--- a/src/wowman/specs.clj
+++ b/src/wowman/specs.clj
@@ -28,6 +28,7 @@
 
 ;; 'expanded' addon summary, everything we need in order to download an addon
 ;; see catalog/expand-addon-summary
+;; todo: rename '::expanded-addon' or similar
 (s/def ::addon
   (s/merge ::addon-summary (s/keys :req-un [::version ::download-uri]
                                    :opt [::donation-uri ::interface-version])))
@@ -40,6 +41,7 @@
 
 ;; the result of merging an installed addon (toc) with an installable addon
 ;; this is very much a utility-type shape for convenience over purity
+;; todo: renamed '::matched-addon' or similar
 (s/def ::toc-addon
   (s/merge ::toc ::addon (s/keys :opt [::update?])))
 

--- a/src/wowman/ui/gui.clj
+++ b/src/wowman/ui/gui.clj
@@ -192,7 +192,7 @@
   ;;(core/-install-update-these (map curseforge/expand-summary (get-state :selected-search))) ;; original approach. efficient but no feedback for user
   (switch-tab INSTALLED-TAB)
   (doseq [selected (get-state :selected-search)]
-    (-> selected core/expand-summary-wrapper vector core/-install-update-these)
+    (some-> selected core/expand-summary-wrapper vector core/-install-update-these)
     (core/load-installed-addons))
   (ss/selection! (select-ui :#tbl-search-addons) nil) ;; deselect rows in search table
   (core/refresh))

--- a/test/wowman/core_test.clj
+++ b/test/wowman/core_test.clj
@@ -271,3 +271,5 @@
           (finally
             (main/stop)))))))
 
+
+;; todo: install classic addon into retail game track


### PR DESCRIPTION
fixes two issues related to WoW game track in 0.9.0

* attempting to install an addon from the search pane that is classic-onlyinto an addon-dir that is 'retail'  (or vice versa) caused a fault
* attempting to re-install an addon that is classic-only into an addon-dir that is 'retail' (or vice versa) caused a fault

These bugs are due to new logic I hadn't anticipated. A match between an installed addon and the catalog may be found, but not necessarily a *release* of that addon matching the addon directory game track (default 'retail').
