### PR TITLE
fixed paths

### DIFF
--- a/src/wowman/core.clj
+++ b/src/wowman/core.clj
@@ -42,9 +42,9 @@
 (def colours (utils/nav-map-fn -colour-map))
 
 (defn generate-path-map
-  "generates a map of filesystem paths whose location may vary according to the current working directory and environment variables.
+  "generates filesystem paths whose location may vary based on the current working directory and environment variables.
   this map of paths is generated during init and is then fixed in application state.
-  ensure the correct environment variables and cwd are set prior to init to ensure isolation during tests"
+  ensure the correct environment variables and cwd are set prior to init for proper isolation during tests"
   []
   (let [;; https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
         ;; ignoring XDG_CONFIG_DIRS and XDG_DATA_DIRS for now

--- a/src/wowman/main.clj
+++ b/src/wowman/main.clj
@@ -9,7 +9,7 @@
    [me.raynes.fs :as fs]
    [wowman
     [logging :as logging]
-    [core :as core :refer [paths]]
+    [core :as core]
     [utils :as utils :refer [in?]]]
    [wowman.ui
     [cli :as cli]
@@ -107,17 +107,6 @@
   (let [{:keys [options errors]} parsed]
     (cond
       (= "root" (System/getProperty "user.name")) {:ok? false, :exit-message "wowman should not be run as the 'root' user"}
-
-      ;; data directory doesn't exist and parent directory isn't writable
-      ;; nowhere to create data dir, nowhere to store download catalog. non-starter
-      (and
-       (not (fs/exists? (paths :data-dir)))
-       (not (fs/writeable? (fs/parent (paths :data-dir))))) {:ok? false, :exit-message (str "Data directory doesn't exist and it cannot be created: " (paths :data-dir))}
-
-      ;; state directory *does* exist but isn't writeable
-      ;; another non-starter
-      (and (fs/exists? (paths :data-dir))
-           (not (fs/writeable? (paths :data-dir)))) {:ok? false, :exit-message (str "Data directory isn't writeable:" (paths :data-dir))}
 
       (:help options) {:ok? true, :exit-message (usage parsed)}
 

--- a/test/wowman/main_test.clj
+++ b/test/wowman/main_test.clj
@@ -1,40 +1,12 @@
 (ns wowman.main-test
   (:require
-   [envvar.core :refer [env with-env]]
    [clojure.test :refer [deftest testing is use-fixtures]]
-   [taoensso.timbre :as timbre :refer [debug info warn error spy]]
-   [me.raynes.fs :as fs :refer [with-cwd]]
-   [clj-http.fake :refer [with-fake-routes-in-isolation]]
+   ;;[taoensso.timbre :as timbre :refer [debug info warn error spy]]
    [wowman
-    [utils :refer [join]]
+    [test-helper :as helper]
     [main :as main]]))
 
-(defn tempcwd-fixture
-  "each test is executed in a new location (accessible as fs/*cwd*)"
-  [f]
-  (let [temp-dir-path (fs/temp-dir "wowman.main-test.")
-        fake-routes {;; catalog
-                     ;; return dummy data. we can do this because the catalog isn't loaded/parsed/validated
-                     ;; until the UI (gui or cli) tells it to via a later call to `refresh`
-                     "https://raw.githubusercontent.com/ogri-la/wowman-data/master/short-catalog.json"
-                     {:get (fn [req] {:status 200 :body "{}"})}
-
-                     ;; latest wowman version
-                     "https://api.github.com/repos/ogri-la/wowman/releases/latest"
-                     {:get (fn [req] {:status 200 :body "{\"tag_name\": \"0.0.0\"}"})}}]
-    (try
-      (with-fake-routes-in-isolation fake-routes
-        (with-env [:xdg-data-home (join temp-dir-path "data")
-                   :xdg-config-home (join temp-dir-path "config")]
-          ;; Is this still necessary any more? I guess it improves test isolation
-          (with-cwd temp-dir-path
-            (debug "created temp working directory" fs/*cwd*)
-            (f))))
-      (finally
-        (debug "destroying temp working directory" fs/*cwd*) ;; "with contents" (vec (file-seq fs/*cwd*)))
-        (fs/delete-dir temp-dir-path)))))
-
-(use-fixtures :each tempcwd-fixture)
+(use-fixtures :each helper/fixture-tempcwd)
 
 (deftest parse-args
   (testing "default ui is 'gui'"

--- a/test/wowman/test_helper.clj
+++ b/test/wowman/test_helper.clj
@@ -5,6 +5,7 @@
    [me.raynes.fs :as fs :refer [with-cwd]]
    [clj-http.fake :refer [with-fake-routes-in-isolation]]
    [wowman
+    [main :as main]
     [utils :as utils]]))
 
 (def fixture-dir (-> "test/fixtures" fs/absolute fs/normalized str))
@@ -41,6 +42,9 @@
                      "https://api.github.com/repos/ogri-la/wowman/releases/latest"
                      {:get (fn [req] {:status 200 :body "{\"tag_name\": \"0.0.0\"}"})}}]
     (try
+      (debug "stopping application if it hasn't already been stopped")
+      (main/stop)
+
       (with-fake-routes-in-isolation fake-routes
         (with-env [:xdg-data-home (utils/join temp-dir-path data-dir)
                    :xdg-config-home (utils/join temp-dir-path config-dir)]


### PR DESCRIPTION
The map of paths is now generated at app initialisation rather than on function call. This ties path access to app initialisation but provides improved isolation while testing because envvars are thread-local and the binding is lost if `paths` is later called from another thread other than the one the app was initialised on (which happens occasionally and when we least expect it).

- [x] review