### PR TITLE
github addons, two bug fixes.

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -61,6 +61,13 @@ for an addon on github to be installable by wowman, it must:
 
 ### todo
 
+* github, non-addon git repo fails to install
+    - https://github.com/koekeishiya/yabai
+    - make this a softer failure
+        - "does not look like an addon"
+* github, look for a .toc file to better determine classic or not
+    - fall back to release name scraping only if a .toc file not found
+        - not finding a toc file may itself be an indication of problems...
 * gitlab as addon host
     - https://gitlab.com/search?search=wow+addon
 * add TUKUI addon host

--- a/src/wowman/core.clj
+++ b/src/wowman/core.clj
@@ -1047,12 +1047,12 @@
   [addon-url string?]
   (when-let [addon-summary (catalog/parse-user-string addon-url)]
     (add-user-addon! addon-summary)
-    (db-reload-catalog)
-    (if-let [addon (expand-summary-wrapper addon-summary)]
-      (do
-        (install-addon addon (get-state :selected-addon-dir)) ;; todo: simplify install-addon interface
-        addon)
-      addon-summary)))
+    (let [result (or (when-let [addon (expand-summary-wrapper addon-summary)]
+                       (install-addon addon (get-state :selected-addon-dir)) ;; todo: simplify install-addon interface
+                       addon)
+                     addon-summary)]
+      (db-reload-catalog)
+      result)))
 
 ;; init
 

--- a/src/wowman/core.clj
+++ b/src/wowman/core.clj
@@ -889,18 +889,6 @@
         sorted-asc (utils/sort-semver-strings [latest-release version-running])]
     (= version-running (last sorted-asc))))
 
-;; installing addons from strings
-
-(defn-spec add+install-user-addon! (s/or :ok ::sp/addon, :failed nil?)
-  "convenience. parses string, adds to user catalog and then installs addon.
-  relies on UI to call refresh (or not)"
-  [addon-url string?]
-  (when-let [parse-results (catalog/parse-user-string addon-url)]
-    (add-user-addon! parse-results)
-    (let [addon (expand-summary-wrapper parse-results)]
-      (install-addon addon (get-state :selected-addon-dir)) ;; todo: simplify install-addon interface
-      addon)))
-
 ;; import/export
 
 (defn-spec export-installed-addon-list nil?
@@ -1045,6 +1033,27 @@
   (-> (get-state) :selected-installed vec remove-many-addons)
   nil)
 
+(defn-spec db-reload-catalog nil?
+  []
+  (locking db-lock
+    (db-shutdown)
+    (refresh)))
+
+;; installing addons from strings
+
+(defn-spec add+install-user-addon! (s/or :ok ::sp/addon, :less-ok ::sp/addon-summary, :failed nil?)
+  "convenience. parses string, adds to user catalog, installs addon then reloads database.
+  relies on UI to call refresh (or not)"
+  [addon-url string?]
+  (when-let [addon-summary (catalog/parse-user-string addon-url)]
+    (add-user-addon! addon-summary)
+    (db-reload-catalog)
+    (if-let [addon (expand-summary-wrapper addon-summary)]
+      (do
+        (install-addon addon (get-state :selected-addon-dir)) ;; todo: simplify install-addon interface
+        addon)
+      addon-summary)))
+
 ;; init
 
 (defn watch-for-addon-dir-change
@@ -1062,10 +1071,7 @@
 (defn watch-for-catalog-change
   "when the catalog changes, the list of available addons should be re-read"
   []
-  (state-bind [:cfg :selected-catalog] (fn [_]
-                                         (locking db-lock
-                                           (db-shutdown)
-                                           (refresh)))))
+  (state-bind [:cfg :selected-catalog] (fn [_] (db-reload-catalog))))
 
 (defn-spec init-dirs nil?
   []

--- a/src/wowman/github_api.clj
+++ b/src/wowman/github_api.clj
@@ -61,7 +61,7 @@
              {:download-uri (:browser_download_url asset)
               :version (:version asset)}))))
 
-(defn-spec extract-source-id string?
+(defn-spec extract-source-id (s/or :ok string?, :error nil?)
   [url ::sp/uri]
   (->> url java.net.URL. .getPath (re-matches #"^/([^/]+/[^/]+)[/]?.*") rest first))
 

--- a/src/wowman/ui/gui.clj
+++ b/src/wowman/ui/gui.clj
@@ -693,17 +693,20 @@
                             :title "Addon URL"
                             :value "https://github.com/")
 
-        spiel "Failed. URL must be:
+        fail "Failed. URL must be:
   * valid
   * originate from github.com
   * addon uses 'releases'
   * latest release has a packaged 'asset'
   * asset must be a .zip file"
 
-        failure-warning #(ss/alert spiel)]
+        failure-warning #(ss/alert fail)
+
+        less-failure-warning #(ss/alert "Failed. Addon successfully added to catalogue but could not be installed.")]
     (when addon-url
-      (if (core/add+install-user-addon! addon-url)
-        (core/refresh)
+      (if-let [result (core/add+install-user-addon! addon-url)]
+        (when-not (contains? result :download-uri)
+          (less-failure-warning))
         (failure-warning))))
   nil)
 

--- a/test/wowman/github_api_test.clj
+++ b/test/wowman/github_api_test.clj
@@ -184,4 +184,18 @@
       (with-fake-routes-in-isolation fake-routes
         (is (= expected (github-api/expand-summary given game-track)))))))
 
+(deftest extract-source-id
+  (let [cases [["https://github.com/Aviana/HealComm" "Aviana/HealComm"] ;; perfect case
+               ["https://github.com/Aviana/HealComm/foo/bar" "Aviana/HealComm"]
+               ["https://github.com/Aviana/HealComm?foo=bar" "Aviana/HealComm"]
+               ["https://github.com/Aviana/HealComm#foo=bar" "Aviana/HealComm"]
+
+               ;; fail cases
+               ["https://github.com" nil]
+               ["https://github.com/" nil]
+               ["https://github.com/Aviana" nil]
+               ["https://github.com/Aviana/" nil]]]
+    (doseq [[given expected] cases]
+      (testing (str "a source-id can be extracted from a github URL, case:" given)
+        (is (= expected (github-api/extract-source-id given)))))))
 

--- a/test/wowman/github_api_test.clj
+++ b/test/wowman/github_api_test.clj
@@ -11,6 +11,9 @@
   (let [fixture (slurp (fixture-path "github-repo-releases--aviana-healcomm.json"))
 
         fake-routes {"https://api.github.com/repos/Aviana/HealComm/releases"
+                     {:get (fn [req] {:status 200 :body fixture})}
+
+                     "https://api.github.com/repos/aviana/healcomm/releases"
                      {:get (fn [req] {:status 200 :body fixture})}}
 
         expected {:uri "https://github.com/Aviana/HealComm"
@@ -32,6 +35,9 @@
                "https://github.com/Aviana/HealComm?foo=bar"
                "https://github.com/Aviana/HealComm#foo/bar"
                "https://github.com/Aviana/HealComm?foo=bar&baz=bup"
+
+               ;; valid, for github
+               "https://github.com/aviana/healcomm" ;; no redirect for lowercase :(
 
                ;; looser matching we can support
                "https://github.com/Aviana/HealComm/foo/bar/baz"


### PR DESCRIPTION
* addon may be successfully added to catalogue but may then fail to install.
* addon now uses data from the releases response to determine the source-id property, rather than derive it from the user input. This was leading to duplicate addons in user catalogue.
* catalogue is now reloaded when an addon is successfully added, regardless of whether it successfully installed or not