### PR TITLE
Fix: export addons bug

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -61,6 +61,7 @@ for an addon on github to be installable by wowman, it must:
 
 ### todo
 
+* bug, export addon list isn't using selected directory
 * github, non-addon git repo fails to install
     - https://github.com/koekeishiya/yabai
     - make this a softer failure
@@ -104,7 +105,7 @@ for an addon on github to be installable by wowman, it must:
     - remove call to set in db-load-catalog
     - I suspect curseforge
 * investigate usage of spec-tools/coerce and remove if unnecessary
-* bug, export addon list isn't using selected directory
+
 * when adding an addon-dir, if path ends with /_classic_/Interface/Addons, set game track to classic
 
 ## todo bucket

--- a/src/wowman/core.clj
+++ b/src/wowman/core.clj
@@ -891,13 +891,14 @@
 
 ;; import/export
 
-(defn-spec export-installed-addon-list nil?
+(defn-spec export-installed-addon-list ::sp/extant-file
   [output-file ::sp/file, addon-list ::sp/toc-list]
-  (let [addon-list (map #(select-keys % [:name :source]) addon-list)]
+  (let [addon-list (map #(select-keys % [:name :source :source-id]) addon-list)]
     (utils/dump-json-file output-file addon-list)
-    (info "wrote:" output-file)))
+    (info "wrote:" output-file)
+    output-file))
 
-(defn-spec export-installed-addon-list-safely nil?
+(defn-spec export-installed-addon-list-safely ::sp/extant-file
   [output-file ::sp/file]
   (let [output-file (-> output-file fs/absolute str)
         output-file (utils/replace-file-ext output-file ".json")

--- a/src/wowman/ui/gui.clj
+++ b/src/wowman/ui/gui.clj
@@ -251,7 +251,9 @@
 (defn configure-app-panel
   []
   (let [picker (fn []
-                 (when-let [dir (chooser/choose-file :type :open ;; ':open' forces a better dialog type in mac for opening directories
+                 (when-let [dir (chooser/choose-file (select-ui :#root)
+                                                     ;; ':open' forces a better dialog type in mac for opening directories
+                                                     :type :open
                                                      :selection-mode :dirs-only)]
                    (if (fs/directory? dir)
                      (do
@@ -670,7 +672,8 @@
 
 (defn export-addon-list-handler
   []
-  (when-let [path (chooser/choose-file :type "Export"
+  (when-let [path (chooser/choose-file (select-ui :#root)
+                                       :type :save
                                        :selection-mode :files-only
                                        :filters [["JSON" ["json"]]]
                                        :success-fn (fn [_ file]
@@ -679,7 +682,8 @@
 
 (defn import-addon-list-handler
   []
-  (when-let [path (chooser/choose-file :type "Import"
+  (when-let [path (chooser/choose-file (select-ui :#root)
+                                       :type :open
                                        :selection-mode :files-only
                                        :filters [["JSON" ["json"]]]
                                        :success-fn (fn [_ file]

--- a/test/wowman/core_test.clj
+++ b/test/wowman/core_test.clj
@@ -10,7 +10,7 @@
     [main :as main]
     [catalog :as catalog]
     [utils :as utils]
-    [test-helper :as helper :refer [fixture-path temp-path data-dir with-running-app]]
+    [test-helper :as helper :refer [fixture-path data-dir with-running-app]]
     [core :as core]]))
 
 (use-fixtures :each helper/fixture-tempcwd)
@@ -230,11 +230,14 @@
 (deftest export-installed-addon-list
   (testing "exported data looks as expected"
     (let [addon-list (read-string (slurp "test/fixtures/export--installed-addons-list.edn"))
-          output-path (temp-path "exports.json")
+          export-dir (utils/join fs/*cwd* "foo" "bar" "exports")
+          _ (fs/mkdirs export-dir)
+          output-path (utils/join export-dir "export.json")
           _ (core/export-installed-addon-list output-path addon-list)
           expected [{:name "adibags" :source "curseforge"}
                     {:name "noname"} ;; an addon whose name is not present in the catalog (umatched)
                     {:name "carbonite" :source "curseforge"}]]
+      (is (fs/exists? output-path))
       (is (= expected (utils/load-json-file output-path))))))
 
 (deftest import-exported-addon-list-file

--- a/test/wowman/curseforge_api_test.clj
+++ b/test/wowman/curseforge_api_test.clj
@@ -5,7 +5,7 @@
    ;;[taoensso.timbre :as log :refer [debug info warn error spy]]
    [wowman
     [curseforge-api :as curseforge-api]
-    [test-helper :as helper :refer [fixture-path temp-path]]]))
+    [test-helper :as helper :refer [fixture-path]]]))
 
 (deftest expand-summary
   (testing "simple addon expansion, ideal conditions"

--- a/test/wowman/gui_test.clj
+++ b/test/wowman/gui_test.clj
@@ -4,7 +4,7 @@
    [wowman.ui.gui :as gui]
    [wowman
     [main :as main]
-    [test-helper :as helper :refer [fixture-path temp-path]]]
+    [test-helper :as helper :refer [fixture-path]]]
   ;;[taoensso.timbre :as log :refer [debug info warn error spy]]
    ))
 

--- a/test/wowman/test_helper.clj
+++ b/test/wowman/test_helper.clj
@@ -18,10 +18,6 @@
   [filename]
   (utils/join fixture-dir filename))
 
-(defn temp-path
-  [filename]
-  (-> filename fs/absolute fs/normalized str))
-
 (defn fixture-tempcwd
   "each test is executed in a new and self-contained location, accessible as fs/*cwd*
   if the app is started:

--- a/test/wowman/utils_test.clj
+++ b/test/wowman/utils_test.clj
@@ -154,9 +154,8 @@
                [["/path/to/foo.ext" "json"] "/path/to/foo.json"]
                [["foo.ext" ".json"] "foo.json"]
                [["foo.ext" "json"] "foo.json"]
-               
-               [["foo" ".json"] "foo.json"]]
-        ]
+
+               [["foo" ".json"] "foo.json"]]]
     (doseq [[[given given-ext] expected] cases]
       (testing (format "a file can have it's extension replaced, case: (%s %s)" given given-ext)
         (is (= expected (utils/replace-file-ext given given-ext)))))))

--- a/test/wowman/utils_test.clj
+++ b/test/wowman/utils_test.clj
@@ -148,3 +148,15 @@
     (doseq [[args expected] cases]
       (testing (str "pattern matches are extracted into a map correctly, case: " args)
         (is (= expected (apply utils/named-regex-groups args)))))))
+
+(deftest replace-file-ext
+  (let [cases [[["/path/to/foo.ext" ".json"] "/path/to/foo.json"]
+               [["/path/to/foo.ext" "json"] "/path/to/foo.json"]
+               [["foo.ext" ".json"] "foo.json"]
+               [["foo.ext" "json"] "foo.json"]
+               
+               [["foo" ".json"] "foo.json"]]
+        ]
+    (doseq [[[given given-ext] expected] cases]
+      (testing (format "a file can have it's extension replaced, case: (%s %s)" given given-ext)
+        (is (= expected (utils/replace-file-ext given given-ext)))))))


### PR DESCRIPTION
* fixes bug with addons export ignoring path
* adds `:source-id` to data that is exported

todo

- [x] addons can still be imported correctly. we've introduced multiple installation dirs since this feature was added
- [x] review