### PR TITLE
user catalog refresh

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -154,6 +154,8 @@ multiple assets will always require differentiation, but we can tune warnings/er
     - necessary if they want a large number of github addons without hassles
 * when curseforge api is down users get a wall of red error messages with very little useful information
     - see issue 91: https://github.com/ogri-la/wowman/issues/91
+        - the error message has been improved but we still get a red wall of text
+        - aggregate error messages?
 * investigate state of java packaging
     - https://www.infoq.com/news/2019/03/jep-343-jpackage/
 * github-api, also look for 'retail' in addon name to determine game track

--- a/TODO.md
+++ b/TODO.md
@@ -110,6 +110,12 @@ multiple assets will always require differentiation, but we can tune warnings/er
 
 ### todo
 
+* allow user to accumulate addons in a 'user' catalogue
+    - how is this catalogue updated?
+        - it will contain information that will remain static after initially created
+        - typically wowman downloads the updated catalogue from remote
+            - that won't happen here
+
 * github, non-addon git repo fails to install
     - https://github.com/koekeishiya/yabai
     - make this a softer failure
@@ -124,11 +130,6 @@ multiple assets will always require differentiation, but we can tune warnings/er
 * allow user to specify their own catalogs
     - a url to a catalog that is downloaded and included while loading up the db
     - different from the 'user catalog'
-* allow user to accumulate addons in a 'user' catalogue
-    - how is this catalogue updated?
-        - it will contain information that will remain static after initially created
-        - typically wowman downloads the updated catalogue from remote
-            - that won't happen here
 * mac support
     - must be included in CI
 * windows support

--- a/TODO.md
+++ b/TODO.md
@@ -150,6 +150,8 @@ multiple assets will always require differentiation, but we can tune warnings/er
 
 ## todo bucket (no particular order)
 
+* add support for user supplied github token
+    - necessary if they want a large number of github addons without hassles
 * when curseforge api is down users get a wall of red error messages with very little useful information
     - see issue 91: https://github.com/ogri-la/wowman/issues/91
 * investigate state of java packaging

--- a/TODO.md
+++ b/TODO.md
@@ -115,6 +115,8 @@ multiple assets will always require differentiation, but we can tune warnings/er
         - it will contain information that will remain static after initially created
         - typically wowman downloads the updated catalogue from remote
             - that won't happen here
+    - I think we could get away with updating this catalogue once a week?
+        - inspect 'last-updated' in user-catalogue
 
 * github, non-addon git repo fails to install
     - https://github.com/koekeishiya/yabai
@@ -148,6 +150,8 @@ multiple assets will always require differentiation, but we can tune warnings/er
 
 ## todo bucket (no particular order)
 
+* when curseforge api is down users get a wall of red error messages with very little useful information
+    - see issue 91: https://github.com/ogri-la/wowman/issues/91
 * investigate state of java packaging
     - https://www.infoq.com/news/2019/03/jep-343-jpackage/
 * github-api, also look for 'retail' in addon name to determine game track

--- a/src/wowman/core.clj
+++ b/src/wowman/core.clj
@@ -800,8 +800,8 @@
       (when-not (empty? final-catalog)
         (-db-load-catalog final-catalog)))))
 
-(defn refresh-user-catalog
-  "for each entry in user catalog, fetch+parse+write"
+(defn-spec refresh-user-catalog nil?
+  "re-fetch each item in user catalog using the URI and replace old entry with any updated details"
   []
   (binding [http/*cache* (cache)]
     (->> (get-create-user-catalog)

--- a/src/wowman/core.clj
+++ b/src/wowman/core.clj
@@ -971,11 +971,6 @@
 
   (check-for-updates)     ;; for those addons that have matches, download their details
 
-  ;; called after checking for updates as most of these will then be cache hits 
-  ;; at two requests per-addon and a github api cap of 60 requests/hour, we're limited to 30 github addons
-  ;; an api request is also made to github for the latest wowman release, so now it's 29 github addons
-  (refresh-user-catalog)
-  
   ;;(latest-wowman-release) ;; check for updates after everything else is done ;; 2019-06-30, travis is failing with 403: Forbidden. Moved to gui init
 
   (save-settings)         ;; seems like a good place to preserve the etag-db

--- a/src/wowman/github_api.clj
+++ b/src/wowman/github_api.clj
@@ -19,7 +19,7 @@
 
 (defn-spec download-releases (s/or :ok (s/coll-of map?), :error nil?)
   [source-id string?]
-  (some-> source-id releases-url http/download utils/from-json))
+  (some-> source-id releases-url http/download http/sink-error utils/from-json))
 
 (defn-spec contents-url ::sp/uri
   [source-id string?]
@@ -27,7 +27,7 @@
 
 (defn-spec download-root-listing (s/or :ok (s/coll-of map?), :error nil?)
   [source-id string?]
-  (some-> source-id contents-url http/download utils/from-json))
+  (some-> source-id contents-url http/download http/sink-error utils/from-json))
 
 (defn-spec find-remote-toc-file (s/or :ok map?, :error nil?)
   "returns the contents of the first .toc file it finds in the root directory of the remote addon"

--- a/src/wowman/github_api.clj
+++ b/src/wowman/github_api.clj
@@ -36,7 +36,7 @@
             toc-file-list (filterv #(-> % :name fs/split-ext last (= ".toc")) contents-listing)
             toc-file (first toc-file-list)]
            (some-> toc-file :download_url http/download toc/-parse-toc-file)
-           (warn (format "failed to find/download/parse remote github '.toc' file for '%s'" source-id))))
+           (debug (format "failed to find/download/parse remote github '.toc' file for '%s'" source-id))))
 
 (defn-spec -find-gametracks-toc-data (s/or :ok ::sp/game-track-list, :empty nil?, :error nil?)
   "returns a set of 'retail' and/or 'classic' after inspecting .toc file contents"

--- a/src/wowman/http.clj
+++ b/src/wowman/http.clj
@@ -152,8 +152,8 @@
                       ;;  - https://github.com/dakrone/clj-http
                       (some-> ex ex-data :body .close))
                   request-obj (java.net.URL. uri)
-                  http-error (assoc (select-keys (ex-data ex) [:reason-phrase :status])
-                                    :host (.getHost request-obj))]
+                  http-error (merge (select-keys (ex-data ex) [:reason-phrase :status])
+                                    {:host (.getHost request-obj)})]
               (warn (format "failed to download file '%s': %s (HTTP %s)"
                             uri (:reason-phrase http-error) (:status http-error)))
 
@@ -176,16 +176,16 @@
       #{"api.github.com" 403} "Github: we've exceeded our request quota and have been blocked for an hour."
 
       ;; issue 91, CDN problems 
-      #{"addons-ecs.forgesvc.net" 502} "Curseforge: their API is having problems right now (502). Try again later."
-      #{"addons-ecs.forgesvc.net" 504} "Curseforge: their API is habing problems right now (504). Trye again later."
+      #{"addons-ecs.forgesvc.net" 502} "Curseforge: the API is having problems right now (502). Try again later."
+      #{"addons-ecs.forgesvc.net" 504} "Curseforge: the API is habing problems right now (504). Trye again later."
 
       #{403} "Forbidden: we've been blocked from accessing that (403)"
 
       (:reason-phrase http-err))))
 
 (defn sink-error
-  "given a http response, if response was unsuccessful, emit warning/error message and return nil, else return response.
-  good for threaded expressions: (some-> x http/download http/sink-error utils/from-json)"
+  "given a http response, if response was unsuccessful, emit warning/error message and return nil,
+  else return response."
   [http-resp]
   (if-not (http-error? http-resp)
     ;; no error, pass response through

--- a/src/wowman/logging.clj
+++ b/src/wowman/logging.clj
@@ -25,6 +25,7 @@
 (logging/merge-config! default-logging-config)
 
 (defn-spec add-appender nil?
+  "adds appender at `key` to logging config"
   ([key keyword?, f fn?]
    (add-appender key f {}))
   ([key keyword?, f fn?, config map?]
@@ -34,6 +35,7 @@
      nil)))
 
 (defn-spec rm-appender! nil?
+  "removes appender at `key` from logging config"
   [key keyword?]
   (logging/merge-config! {:appenders {key nil}})
   nil)

--- a/src/wowman/specs.clj
+++ b/src/wowman/specs.clj
@@ -127,7 +127,8 @@
 
 (s/def ::reason-phrase (s/and string? #(<= (count %) 50)))
 (s/def ::status int?) ;; a little too general but ok for now
-(s/def ::http-error (s/keys :req-un [::reason-phrase ::status]))
+(s/def ::host string?)
+(s/def ::http-error (s/keys :req-un [::reason-phrase ::status ::host]))
 (s/def ::body any?) ;; even a nil body is allowed (304 Not Modified)
 (s/def ::http-resp (s/keys :req-un [::status ::body])) ;; *at least* these keys, it will definitely have others
 

--- a/src/wowman/ui/gui.clj
+++ b/src/wowman/ui/gui.clj
@@ -772,7 +772,9 @@
                    :separator
                    (ss/action :name "Exit" :key "menu Q" :mnemonic "x" :handler (handler #(ss/dispose! newui)))]
 
-        catalog-menu (build-catalog-menu)
+        catalog-menu (into (build-catalog-menu)
+                           [:separator
+                            (ss/action :name "Refresh user catalog" :handler (async-handler core/refresh-user-catalog))])
 
         addon-menu [(ss/action :name "Update all" :key "menu U" :mnemonic "u" :handler (async-handler core/install-update-all))
                     (ss/action :name "Re-install all" :handler (async-handler core/re-install-all))

--- a/src/wowman/utils.clj
+++ b/src/wowman/utils.clj
@@ -276,7 +276,7 @@
 
 (defn from-json
   [x]
-  (clojure.data.json/read-str x :key-fn keyword))
+  (some-> x (clojure.data.json/read-str :key-fn keyword)))
 
 (defn-spec dump-json-file ::sp/extant-file
   [path ::sp/file, data ::sp/anything]

--- a/test/wowman/core_test.clj
+++ b/test/wowman/core_test.clj
@@ -536,40 +536,40 @@
 ;;
 
 (deftest add-user-addon-to-user-catalog
-  (let [user-addon {:uri "https://github.com/Aviana/HealComm"
-                    :updated-date "2019-10-09T17:40:01Z"
-                    :source "github"
-                    :source-id "Aviana/HealComm"
-                    :label "HealComm"
-                    :name "healcomm"
-                    :download-count 30946
-                    :category-list []}
+  (testing "user addon is successfully added to the user catalog, creating it if it doesn't exist"
+    (let [user-addon {:uri "https://github.com/Aviana/HealComm"
+                      :updated-date "2019-10-09T17:40:01Z"
+                      :source "github"
+                      :source-id "Aviana/HealComm"
+                      :label "HealComm"
+                      :name "healcomm"
+                      :download-count 30946
+                      :category-list []}
 
-        expected (merge (catalog/new-catalog [])
-                        {;; hack, catalog/format-catalog-data orders the addon summary make them uncomparable
-                         :total 1
-                         :addon-summary-list [user-addon]})]
+          expected (merge (catalog/new-catalog [])
+                          {;; hack, catalog/format-catalog-data orders the addon summary make them uncomparable
+                           :total 1
+                           :addon-summary-list [user-addon]})]
 
-    (testing "user addon is successfully added to the user catalog, creating it if it doesn't exist"
       (with-running-app
         (core/add-user-addon! user-addon)
         (is (= expected (catalog/read-catalog (core/paths :user-catalog-file)))))))
 
-  (let [user-addon {:uri "https://github.com/Aviana/HealComm"
-                    :updated-date "2019-10-09T17:40:01Z"
-                    :source "github"
-                    :source-id "Aviana/HealComm"
-                    :label "HealComm"
-                    :name "healcomm"
-                    :download-count 30946
-                    :category-list []}
+  (testing "adding addons to the user catalogue is idempotent"
+    (let [user-addon {:uri "https://github.com/Aviana/HealComm"
+                      :updated-date "2019-10-09T17:40:01Z"
+                      :source "github"
+                      :source-id "Aviana/HealComm"
+                      :label "HealComm"
+                      :name "healcomm"
+                      :download-count 30946
+                      :category-list []}
 
-        expected (merge (catalog/new-catalog [])
-                        {;; hack, catalog/format-catalog-data orders the addon summary make them uncomparable
-                         :total 1
-                         :addon-summary-list [user-addon]})]
-
-    (testing "adding addons to the user catalogue is idempotent"
+          expected (merge (catalog/new-catalog [])
+                          {;; hack, catalog/format-catalog-data orders the addon summary make them uncomparable
+                           :total 1
+                           :addon-summary-list [user-addon]})]
+      
       (with-running-app
         (core/add-user-addon! user-addon)
         (core/add-user-addon! user-addon)

--- a/test/wowman/core_test.clj
+++ b/test/wowman/core_test.clj
@@ -569,7 +569,7 @@
                           {;; hack, catalog/format-catalog-data orders the addon summary make them uncomparable
                            :total 1
                            :addon-summary-list [user-addon]})]
-      
+
       (with-running-app
         (core/add-user-addon! user-addon)
         (core/add-user-addon! user-addon)

--- a/test/wowman/github_api_test.clj
+++ b/test/wowman/github_api_test.clj
@@ -317,4 +317,33 @@
 
       (with-fake-routes-in-isolation fake-routes
         (is (= expected (logging/buffered-log
-                         :info (github-api/parse-user-string given))))))))
+                         :info (github-api/parse-user-string given)))))))
+
+  (testing "403 while expanding addon is handled"
+    (let [fake-routes {"https://api.github.com/repos/Aviana/HealComm/releases"
+                       {:get (fn [_] {:status 403 :host "api.github.com" :reason-phrase "Forbidden"})}
+
+                       "https://api.github.com/repos/Aviana/HealComm/contents"
+                       {:get (fn [req] {:status 403 :host "api.github.com" :reason-phrase "Forbidden"})}}
+
+          addon-summary
+          {:uri "https://github.com/Aviana/HealComm"
+           :updated-date "2019-10-09T17:40:04Z"
+           :source "github"
+           :source-id "Aviana/HealComm"
+           :label "HealComm"
+           :name "healcomm"
+           :download-count 30946
+           :game-track-list [] ;; 'no game tracks'
+           :category-list []}
+
+          game-track "retail"
+
+          ;; I don't like testing for log messages, but in this case it's the only indication the error has been handled properly
+          expected ["failed to download file 'https://api.github.com/repos/Aviana/HealComm/releases': Forbidden (HTTP 403)"
+                    "Github: we've exceeded our request quota and have been blocked for an hour."
+                    "no 'retail' release available for 'healcomm' on github"]]
+
+      (with-fake-routes-in-isolation fake-routes
+        (is (= expected (logging/buffered-log
+                         :info (github-api/expand-summary addon-summary game-track))))))))


### PR DESCRIPTION
* github-api calls are now cached. this is important because you get 60 requests/hour without an api token

todo:
- [x] ~user catalogue entries are refreshed on app start~ impractical^
- [x] handle 403 responses from github ([api quota exceeded](https://developer.github.com/v3/#rate-limiting), [forbidden](https://developer.github.com/v3/#abuse-rate-limits))
- [ ] review

---

- ^ it takes two requests to github to refresh a user catalogue addon with a cap of 60 requests/hour. one request is used looking up latest wowman release information. I've instead made a manual refresh button while I think about gradual updates a bit more.