### PR TITLE
fix for XDG paths

### DIFF
--- a/src/wowman/core.clj
+++ b/src/wowman/core.clj
@@ -1085,13 +1085,9 @@
   ;; data directory doesn't exist and parent directory isn't writable
   ;; nowhere to create data dir, nowhere to store download catalog. non-starter
 
-  ;;(when-not (fs/exists? (paths :data-dir))
-  ;;  (throw (RuntimeException. (str "Data directory doesn't exist: " (paths :data-dir)))))
-
   (when (and
-         (not (fs/exists? (paths :data-dir)))
-         ;; :data-dir => "/xdg/data/path/wowman/data"
-         (not (fs/writeable? (fs/parent (fs/parent (paths :data-dir))))))
+         (not (fs/exists? (paths :data-dir))) ;; doesn't exist and ..
+         (not (utils/last-writeable-dir (paths :data-dir)))) ;; .. no writeable parent
     (throw (RuntimeException. (str "Data directory doesn't exist and it cannot be created: " (paths :data-dir)))))
 
   ;; state directory *does* exist but isn't writeable

--- a/src/wowman/utils.clj
+++ b/src/wowman/utils.clj
@@ -529,6 +529,13 @@
        `(let [temp# ~(inner bindings)]
           (if (= temp# ~if-let-else) ~else temp#))))))
 
+;;
+
+(defn-spec expand-path ::sp/file
+  "given a path, expands any 'user' directories, relative directories and symbolic links"
+  [path ::sp/file]
+  (-> path fs/expand-home fs/normalized fs/absolute str))
+
 
 ;;
 

--- a/src/wowman/utils.clj
+++ b/src/wowman/utils.clj
@@ -536,6 +536,13 @@
   [path ::sp/file]
   (-> path fs/expand-home fs/normalized fs/absolute str))
 
+(defn last-writeable-dir
+  "given a path, returns the last writable directory or nil if no writable directory available"
+  [path]
+  (when path
+    (if (and (fs/directory? path) (fs/writeable? path))
+      (str path)
+      (last-writeable-dir (fs/parent path)))))
 
 ;;
 

--- a/test/wowman/core_test.clj
+++ b/test/wowman/core_test.clj
@@ -10,7 +10,7 @@
     [main :as main]
     [catalog :as catalog]
     [utils :as utils]
-    [test-helper :as helper :refer [fixture-path data-dir config-dir with-running-app]]
+    [test-helper :as helper :refer [fixture-path helper-data-dir with-running-app]]
     [core :as core]]))
 
 (use-fixtures :each helper/fixture-tempcwd)
@@ -126,11 +126,11 @@
         (is (= full-catalog (core/get-catalog-source))))
 
       (testing "core/catalog-local-path returns the expected path to the catalog file on the filesystem"
-        (is (= (utils/join fs/*cwd* data-dir "short-catalog.json") (core/catalog-local-path short-catalog)))
-        (is (= (utils/join fs/*cwd* data-dir "full-catalog.json") (core/catalog-local-path full-catalog))))
+        (is (= (utils/join fs/*cwd* helper-data-dir "short-catalog.json") (core/catalog-local-path short-catalog)))
+        (is (= (utils/join fs/*cwd* helper-data-dir "full-catalog.json") (core/catalog-local-path full-catalog))))
 
       (testing "core/find-catalog-local-path just needs a catalog :name"
-        (is (= (utils/join fs/*cwd* data-dir "short-catalog.json") (core/find-catalog-local-path :short))))
+        (is (= (utils/join fs/*cwd* helper-data-dir "short-catalog.json") (core/find-catalog-local-path :short))))
 
       (testing "core/find-catalog-local-path returns nil if the given catalog can't be found"
         (is (= nil (core/find-catalog-local-path :foo))))

--- a/test/wowman/core_test.clj
+++ b/test/wowman/core_test.clj
@@ -10,7 +10,7 @@
     [main :as main]
     [catalog :as catalog]
     [utils :as utils]
-    [test-helper :as helper :refer [fixture-path data-dir with-running-app]]
+    [test-helper :as helper :refer [fixture-path data-dir config-dir with-running-app]]
     [core :as core]]))
 
 (use-fixtures :each helper/fixture-tempcwd)
@@ -139,38 +139,43 @@
         (core/stop app-state)))))
 
 (deftest paths
-  (let [app-state (core/start {})]
-    (try
-      (testing "all path keys are using a known suffix"
-        (doseq [key (keys (core/paths))]
-          (is (some #{"dir" "file" "uri"} (clojure.string/split (name key) #"\-")))))
+  (with-running-app
+    (testing "all path keys are using a known suffix"
+      (doseq [key (keys (core/paths))]
+        (is (some #{"dir" "file" "uri"} (clojure.string/split (name key) #"\-")))))
 
-      (testing "all paths to files and directories are absolute"
-        (let [files+dirs (filter (fn [[k v]] (or (ends-with? k "-dir")
-                                                 (ends-with? k "-file")))
-                                 (core/paths))]
-          (doseq [[key path] files+dirs]
-            (is (-> path (starts-with? "/")) (format "path %s is not absolute: %s" key path)))))
+    (testing "all paths to files and directories are absolute"
+      (let [files+dirs (filter (fn [[k v]] (or (ends-with? k "-dir")
+                                               (ends-with? k "-file")))
+                               (core/paths))]
+        (doseq [[key path] files+dirs]
+          (is (-> path (starts-with? "/")) (format "path %s is not absolute: %s" key path)))))
 
-      (testing "all remote paths are using https"
-        (let [remote-paths (filter (fn [[k v]] (ends-with? k "-uri")) (core/paths))]
-          (doseq [[key path] remote-paths]
-            (is (-> path (starts-with? "https://")) (format "remote path %s is not using HTTPS: %s" key path)))))
+    (testing "all remote paths are using https"
+      (let [remote-paths (filter (fn [[k v]] (ends-with? k "-uri")) (core/paths))]
+        (doseq [[key path] remote-paths]
+          (is (-> path (starts-with? "https://")) (format "remote path %s is not using HTTPS: %s" key path))))))
 
-      (comment
-        "what exactly am I testing here again? this path overriding has plenty of coverage already. see test_helper.clj"
-        (testing "XDG data paths can be overridden with environment variables"
-          (with-env [:xdg-data-home "/foo", :xdg-config-home "/bar"]
-            (is (= "/foo" (:data-dir (core/paths))))
-            (is (= "/bar" (:config-dir (core/paths)))))))
+  (testing "paths that cannot be written to raise a runtime exception"
+    (let [app-state (core/start {})]
+      (with-env [:xdg-data-home "/foo", :xdg-config-home "/bar"]
+        (core/stop app-state)
+        (is (thrown? RuntimeException (core/start {})))))))
 
-      (testing "paths that cannot be written to raise a runtime exception"
-        (with-env [:xdg-data-home "/foo", :xdg-config-home "/bar"]
-          (core/stop app-state)
-          (is (thrown? RuntimeException (core/start {})))))
+(deftest generate-path-map
+  (testing "XDG data paths can be overridden with environment variables"
+    (with-env [:xdg-data-home "/foo", :xdg-config-home "/home/layday/.config"]
+      (let [paths (core/generate-path-map)]
+        (is (= "/foo/wowman" (:data-dir paths)))
+        (is (= "/home/layday/.config/wowman" (:config-dir paths))))))
 
-      (finally
-        (core/stop app-state)))))
+  (testing "XDG data paths are ignored if present, but empty"
+    (with-env [:xdg-data-home "", :xdg-config-home ""]
+      (let [paths (core/generate-path-map)
+            expected-config-dir (-> core/default-config-dir utils/expand-path)
+            expected-data-dir (-> core/default-data-dir utils/expand-path)]
+        (is (= expected-data-dir (:data-dir paths)))
+        (is (= expected-config-dir (:config-dir paths)))))))
 
 (deftest determine-primary-subdir
   (testing "basic failure cases"

--- a/test/wowman/test_helper.clj
+++ b/test/wowman/test_helper.clj
@@ -10,9 +10,9 @@
 
 (def fixture-dir (-> "test/fixtures" fs/absolute fs/normalized str))
 
-(def data-dir "data/wowman")
+(def helper-data-dir "data/wowman")
 
-(def config-dir "config/wowman")
+(def helper-config-dir "config/wowman")
 
 (defn fixture-path
   [filename]
@@ -42,8 +42,8 @@
       (main/stop)
 
       (with-fake-routes-in-isolation fake-routes
-        (with-env [:xdg-data-home (utils/join temp-dir-path data-dir)
-                   :xdg-config-home (utils/join temp-dir-path config-dir)]
+        (with-env [:xdg-data-home (utils/join temp-dir-path helper-data-dir)
+                   :xdg-config-home (utils/join temp-dir-path helper-config-dir)]
           (with-cwd temp-dir-path
             (debug "created temp working directory" fs/*cwd*)
             (f))))

--- a/test/wowman/test_helper.clj
+++ b/test/wowman/test_helper.clj
@@ -10,9 +10,9 @@
 
 (def fixture-dir (-> "test/fixtures" fs/absolute fs/normalized str))
 
-(def data-dir "data")
+(def data-dir "data/wowman")
 
-(def config-dir "config")
+(def config-dir "config/wowman")
 
 (defn fixture-path
   [filename]


### PR DESCRIPTION
* wowman now looks in a 'wowman' subdir when XDG paths specified
* empty XDG paths are ignored in favour of defaults

- [x] double check readme
- [x] review