### PR TITLE
windows support

### DIFF
--- a/src/wowman/utils.clj
+++ b/src/wowman/utils.clj
@@ -544,6 +544,43 @@
       (str path)
       (last-writeable-dir (fs/parent path)))))
 
+;; fs
+
+(defn-spec prefix string?
+  "given a string and a prefix, if string doesn't start with prefix, prefix string else return string as-is"
+  [string string?, prefix string?]
+  (if-not (clojure.string/starts-with? string prefix)
+    (str prefix string)
+    string))
+
+(defn fs-parent
+  [path]
+  (let [path-string (-> path (or "") (clojure.string/trim))
+        string-length (count path-string)
+        last-slash-idx (clojure.string/last-index-of path-string "/")]
+    (cond
+      (= path-string "/") nil
+
+      (nil? last-slash-idx) nil
+
+      ;; no separator found or we've reached the end of the recursion/given an empty string
+      (or
+       (= last-slash-idx 0)
+       (= string-length 0)) "/"
+
+      ;; target is a directory, call again without trailing slash
+      (= string-length last-slash-idx) (fs-parent (subs path-string 0 last-slash-idx))
+
+      ;; return everything up to the last slash
+      :else (subs path-string 0 last-slash-idx))))
+
+;; https://github.com/Raynes/fs/blob/master/src/me/raynes/fs.clj#L544-L548
+(defn fs-parent-list
+  [path]
+  (when-let [parent (fs-parent path)]
+    (cons parent (fs-parent-list parent))))
+
+
 ;;
 
 

--- a/src/wowman/utils.clj
+++ b/src/wowman/utils.clj
@@ -555,7 +555,7 @@
 
 (defn fs-parent
   [path]
-  (let [path-string (-> path (or "") (clojure.string/trim))
+  (let [path-string (-> path (or "") clojure.string/trim)
         string-length (count path-string)
         last-slash-idx (clojure.string/last-index-of path-string "/")]
     (cond
@@ -563,10 +563,9 @@
 
       (nil? last-slash-idx) nil
 
-      ;; no separator found or we've reached the end of the recursion/given an empty string
-      (or
-       (= last-slash-idx 0)
-       (= string-length 0)) "/"
+      ;; given a "/" or reached the penultimate step in the recursion, where going any further
+      ;; backwards leads to an empty string and thus to nil (empty strings have no root/are relative)
+      (= last-slash-idx 0) "/"
 
       ;; target is a directory, call again without trailing slash
       (= string-length last-slash-idx) (fs-parent (subs path-string 0 last-slash-idx))

--- a/src/wowman/utils.clj
+++ b/src/wowman/utils.clj
@@ -400,12 +400,17 @@
     (clojure.string/replace s pattern "")))
 
 (defn-spec replace-file-ext (s/or :ok ::sp/file, :error nil?)
-  [path ::sp/file, ext string?]
-  (let [ext (ltrim ext ".")
-        ext (str "." ext)
-        ;; "foo" => nil, "foo/bar" => ["foo"], "/foo/bar" => ["/" "foo"]
-        parent (some->> (-> path fs/split butlast) (apply join))]
-    (join parent (-> path str fs/split-ext first (str ext)))))
+  [path ::sp/file, new-ext string?]
+  (let [path (java.io.File. path)
+        parent (.getParent path)
+        base-name (.getName path)
+        ext-idx (clojure.string/index-of base-name ".")
+        ;; foo.ext => foo
+        base-name-sans-ext (if ext-idx
+                             (subs base-name 0 ext-idx)
+                             base-name)
+        new-ext (ltrim new-ext ".")]
+    (join parent (str base-name-sans-ext "." new-ext))))
 
 ;; repurposing
 (defn-spec file-to-lazy-byte-array bytes?
@@ -546,12 +551,13 @@
 
 ;; fs
 
+(comment "unused"
 (defn-spec prefix string?
   "given a string and a prefix, if string doesn't start with prefix, prefix string else return string as-is"
   [string string?, prefix string?]
   (if-not (clojure.string/starts-with? string prefix)
     (str prefix string)
-    string))
+    string)))
 
 (defn fs-parent
   [path]

--- a/src/wowman/zip.clj
+++ b/src/wowman/zip.clj
@@ -49,7 +49,7 @@
   (let [mkrow (fn [zipentry]
                 (let [path (.getName zipentry)
                       dir? (.isDirectory zipentry)
-                      bits (split path (re-pattern java.io.File/separator))
+                      bits (split path #"/")
                       level (count bits)]
                   {:dir? dir?
                    :level level

--- a/test/wowman/test_helper.clj
+++ b/test/wowman/test_helper.clj
@@ -6,17 +6,17 @@
    [clj-http.fake :refer [with-fake-routes-in-isolation]]
    [wowman
     [main :as main]
-    [utils :as utils]]))
+    [utils :as utils :refer [join]]]))
 
-(def fixture-dir (-> "test/fixtures" fs/absolute fs/normalized str))
+(def fixture-dir (-> (join "test" "fixtures") fs/absolute fs/normalized str))
 
-(def helper-data-dir "data/wowman")
+(def helper-data-dir (join "data" "wowman"))
 
-(def helper-config-dir "config/wowman")
+(def helper-config-dir (join "config" "wowman"))
 
 (defn fixture-path
   [filename]
-  (utils/join fixture-dir filename))
+  (join fixture-dir filename))
 
 (defn fixture-tempcwd
   "each test is executed in a new and self-contained location, accessible as fs/*cwd*
@@ -43,8 +43,8 @@
       (main/stop)
 
       (with-fake-routes-in-isolation fake-routes
-        (with-env [:xdg-data-home (utils/join temp-dir-path helper-data-dir)
-                   :xdg-config-home (utils/join temp-dir-path helper-config-dir)]
+        (with-env [:xdg-data-home (join temp-dir-path helper-data-dir)
+                   :xdg-config-home (join temp-dir-path helper-config-dir)]
           (with-cwd temp-dir-path
             (debug "created temp working directory" fs/*cwd*)
             (f))))

--- a/test/wowman/utils_test.clj
+++ b/test/wowman/utils_test.clj
@@ -200,3 +200,43 @@
       (testing (format "'any', case: (%s %s)" given expected)
         (is (= expected (utils/any given)))))))
 
+(deftest fs-parents
+  (testing ""
+    (let [cases [;; root has no parents
+                 ["/" nil]
+
+                 ;; file in root has root as parent
+                 ["/foo" ["/"]]
+
+                 ;; file in subdir has the subdir and root as parents
+                 ["/foo/bar" ["/foo" "/"]]
+
+                 ;; files with extensions are no exception
+                 ["/foo/bar.ext" ["/foo" "/"]]
+
+                 ;; this is where it differs from me.raynes.fs
+                 ;; * the parent of everything is root, except root
+                 ;; * assume root can't be determined with relative paths so don't assume fs/*cwd*
+
+                 ;; relative paths
+                 ["foo" nil]
+                 ["foo.ext" nil]
+                 ["foo/bar" ["foo"]]
+                 ["foo/bar/baz.ext" ["foo/bar" "foo"]]
+
+                 ;; empty/blank strings, whitespace
+                 ["" nil]
+                 ["  " nil]
+                 ["    /    " nil]
+
+                 ;; whitespace within paths is preserved?
+                 ;; this behaviour matches me.raynes.fs/java.io.File
+                 ["foo / bar" ["foo "]]
+
+                 ;; double-root
+                 ;; there can be only one /highlander
+                 ["//" ["/"]]
+                 ["//foo" ["/"]]]]
+      (doseq [[given expected] cases]
+        (is (= expected (utils/fs-parent-list given)), (format "given '%s' I expected '%s'" given expected))))))
+


### PR DESCRIPTION
* ZipEntry objects use posix-style paths and *not* windows-style paths, so the `java.io.File` logic in `me.raynes.fs` mis-handles them leading to Weirdness