### PR TITLE
Missing description regression

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -178,6 +178,7 @@ multiple assets will always require differentiation, but we can tune warnings/er
 
 ## todo bucket (no particular order)
 
+* bug, selected directory is incorrect after restarting gui (by switching themes)
 * add custom highlighting colours
     - I don't mind my colours but not everybody may
     - my colours don't work very well on native lnf + dark themes:

--- a/TODO.md
+++ b/TODO.md
@@ -157,11 +157,12 @@ multiple assets will always require differentiation, but we can tune warnings/er
 * bug, if an addon directory goes missing between restarts, user configuration is lost
     - initially it's ignored, but then the new settings are saved over the top
     - done
+* themes
+    - added a 'dark' theme for those using dark widget sets
+        - https://github.com/ogri-la/wowman/issues/105
 
 ### todo
 
-* user catalogue belongs in the .config/wowman/user-catalog.json 
-    - ideally, right?
 * github, description is missing?
     - I think this is what is happening:
         - catalog has no description
@@ -177,7 +178,7 @@ multiple assets will always require differentiation, but we can tune warnings/er
 
 ## todo bucket (no particular order)
 
-* add custom highlighting colours 
+* add custom highlighting colours
     - I don't mind my colours but not everybody may
     - my colours don't work very well on native lnf + dark themes:
         - https://github.com/ogri-la/wowman/issues/105

--- a/src/wowman/core.clj
+++ b/src/wowman/core.clj
@@ -580,10 +580,12 @@
         (http/download-file remote-catalog local-catalog :message (format "downloading catalog '%s'" (:label catalog-source))))
       (error "failed to find catalog:" catalog))))
 
-(defn moosh-addons
-  "merges left->right. catalog-addon overwrites installed-addon, ':matched' overwrites catalog-addon, etc"
-  [installed-addon db-catalog-addon]
-  (let [db-catalog-addon (utils/drop-nils db-catalog-addon [:description])]
+(defn-spec moosh-addons ::sp/toc-addon-summary
+  "merges the data from an installed addon with it's match in the catalog"
+  [installed-addon ::sp/toc, db-catalog-addon ::sp/addon-summary]
+  (let [;; nil fields are removed from the catalog item because they might override good values in the .toc or .nfo
+        db-catalog-addon (utils/drop-nils db-catalog-addon [:description])]
+    ;; merges left->right. catalog-addon overwrites installed-addon, ':matched' overwrites catalog-addon, etc
     (merge installed-addon db-catalog-addon {:matched? true})))
 
 

--- a/src/wowman/core.clj
+++ b/src/wowman/core.clj
@@ -639,14 +639,6 @@
        :match match
        :final (moosh-addons installed-addon match)})))
 
-(defn drop-nils
-  [m fields]
-  (if (empty? fields)
-    m
-    (drop-nils
-     (if (nil? (get m (first fields))) (dissoc m (first fields)) m)
-     (rest fields))))
-
 (defn find-first-in-db
   [installed-addon match-on-list]
   (if (empty? match-on-list) ;; we may have exhausted all possibilities. not finding a match is ok
@@ -684,17 +676,12 @@
           [matched unmatched] (utils/split-filter #(contains? % :final) match-results)
 
           merge-matched (fn [match]
-                          ;;matched (merge installed-addon (spy :info (drop-nils match [:description])))))))
-                          (let [db-result (:final match)
-                                db-result (drop-nils db-result [:description])
-                                installed (:installed-addon match)]
-                            ;; this is essentially the old 'merge-addons' function
-                            (merge installed db-result)))
+                          ;; this is essentially the old 'merge-addons' function
+                          (let [db-catalog-addon (-> match :final (utils/drop-nils [:description]))
+                                installed-addon (:installed-addon match)]
+                            (merge installed-addon db-catalog-addon)))
 
-          matched (mapv :final matched)
-
-          ;; todo: this fixes a regression where empty db data overrides data in installed addons
-          ;;matched (mapv merge-matched matched)
+          matched (mapv merge-matched matched)
 
           unmatched-names (set (map :name unmatched))
 

--- a/src/wowman/core.clj
+++ b/src/wowman/core.clj
@@ -581,9 +581,10 @@
       (error "failed to find catalog:" catalog))))
 
 (defn moosh-addons
-  [installed-addon catalog-addon]
-  ;; merges left->right. catalog-addon overwrites installed-addon, ':matched' overwrites catalog-addon, etc
-  (merge installed-addon catalog-addon {:matched? true}))
+  "merges left->right. catalog-addon overwrites installed-addon, ':matched' overwrites catalog-addon, etc"
+  [installed-addon db-catalog-addon]
+  (let [db-catalog-addon (utils/drop-nils db-catalog-addon [:description])]
+    (merge installed-addon db-catalog-addon {:matched? true})))
 
 
 ;;
@@ -675,13 +676,7 @@
           match-results (-db-match-installed-addons-with-catalog inst-addons)
           [matched unmatched] (utils/split-filter #(contains? % :final) match-results)
 
-          merge-matched (fn [match]
-                          ;; this is essentially the old 'merge-addons' function
-                          (let [db-catalog-addon (-> match :final (utils/drop-nils [:description]))
-                                installed-addon (:installed-addon match)]
-                            (merge installed-addon db-catalog-addon)))
-
-          matched (mapv merge-matched matched)
+          matched (mapv :final matched)
 
           unmatched-names (set (map :name unmatched))
 

--- a/src/wowman/specs.clj
+++ b/src/wowman/specs.clj
@@ -38,9 +38,11 @@
   (s/keys :req-un [::name ::label ::description ::dirname ::interface-version ::installed-version]
           :opt [::group-id ::primary? ::group-addons]))
 
-;; the result of merging an installed addon (toc) with an installable addon
-;; this is very much a utility-type shape for convenience over purity
-;; todo: renamed '::matched-addon' or similar
+;; the result of merging an installed addon (toc) with an installable addon from the catalogue
+(s/def ::toc-addon-summary
+  (s/merge ::toc ::addon-summary (s/keys :opt [::matched?])))
+
+;; the result of 'expanding' an ::toc-addon-summary (matched addon) with further fields from addon host
 (s/def ::toc-addon
   (s/merge ::toc ::addon (s/keys :opt [::update?])))
 
@@ -73,7 +75,7 @@
 (s/def ::label string?) ;; name of the addon without normalisation
 (s/def ::dirname string?)
 (s/def ::description (s/nilable string?))
-
+(s/def ::matched? boolean?)
 (s/def ::group-id string?)
 (s/def ::primary boolean?)
 (s/def ::group-addons ::toc-list)

--- a/src/wowman/utils.clj
+++ b/src/wowman/utils.clj
@@ -544,9 +544,9 @@
       (str path)
       (last-writeable-dir (fs/parent path)))))
 
-(defn drop-nils
-  "given a map and a set of fields, if field is nil, dissoc it"
-  [m fields]
+(defn-spec drop-nils (s/or :ok map?, :empty nil?)
+  "given a map `m` and a set of `fields`, if field is `nil`, `dissoc` it"
+  [m map?, fields sequential?]
   (if (empty? fields)
     m
     (drop-nils

--- a/src/wowman/utils.clj
+++ b/src/wowman/utils.clj
@@ -544,6 +544,17 @@
       (str path)
       (last-writeable-dir (fs/parent path)))))
 
+(defn drop-nils
+  "given a map and a set of fields, if field is nil, dissoc it"
+  [m fields]
+  (if (empty? fields)
+    m
+    (drop-nils
+     (if (nil? (get m (first fields)))
+       (dissoc m (first fields))
+       m)
+     (rest fields))))
+
 ;;
 
 

--- a/test/wowman/core_test.clj
+++ b/test/wowman/core_test.clj
@@ -283,7 +283,7 @@
             (main/stop)))))))
 
 (deftest check-for-update
-  (testing "the key :update? is set on an addon when there is a difference between the installed version of an addon and it's matching catalog verison"
+  (testing "the key :update? is set on an addon when there is a difference between the installed version of an addon and it's matching catalog version"
 
     (let [;; we start off with a list of these called a catalog. it's downloaded from github
           catalog {:category-list ["Auction House & Vendors"],

--- a/test/wowman/core_test.clj
+++ b/test/wowman/core_test.clj
@@ -603,3 +603,44 @@
 
           ;; addon was successfully download and installed
           (is (fs/exists? expected-addon-dir)))))))
+
+(deftest moosh-addons
+  (testing "addons are mooshed together just right when a match is found in the db"
+    (let [toc {:name "everyaddon"
+               :label "EveryAddon"
+               :description "Toc Description"
+               :dirname "EveryAddon"
+               :interface-version 70000
+               :installed-version "1.2.3"}
+
+          addon-summary {:name "everyaddon"
+                         :label "EveryAddon"
+                         :category-list []
+                         :updated-date "2001-01-01"
+                         :download-count 123
+                         :source "wowinterface"
+                         :source-id 1
+                         :uri "https://www.wowinterface.com/downloads/info1"
+
+                       ;; wowinterface and tukui don't have descriptions in their api
+                       ;; the database will return a field with `nil` if the addon-summary
+                       ;; was inserted without one
+                         :description nil}
+
+          expected {:name "everyaddon"
+                    :label "EveryAddon"
+                    :description "Toc Description"
+                    :dirname "EveryAddon"
+                    :interface-version 70000
+                    :installed-version "1.2.3"
+
+                    :category-list []
+                    :updated-date "2001-01-01"
+                    :download-count 123
+                    :source "wowinterface"
+                    :source-id 1
+                    :uri "https://www.wowinterface.com/downloads/info1"
+
+                  ;; optional, lets the GUI know we have a match that can be checked for updates
+                    :matched? true}]
+      (is (= expected (core/moosh-addons toc addon-summary))))))

--- a/test/wowman/utils_test.clj
+++ b/test/wowman/utils_test.clj
@@ -200,3 +200,19 @@
       (testing (format "'any', case: (%s %s)" given expected)
         (is (= expected (utils/any given)))))))
 
+(deftest drop-nils
+  (let [cases [[{} [] {}]
+               [{} [:foo] {}]
+               [{} [nil] {}]
+               [{} ["foo"] {}]
+
+               [{:foo nil} [] {:foo nil}]
+               [{:foo nil} [:foo] {}]
+               [{:foo :bar} [:foo] {:foo :bar}]
+               [{:foo :bar, :bar nil} [:foo] {:foo :bar, :bar nil}]
+               [{:foo :bar, :bar nil} [:bar] {:foo :bar}]]]
+
+    (doseq [[m fields expected] cases]
+      (testing (format "'drop-nils', case: (%s %s => %s)" m fields expected)
+        (is (= expected (utils/drop-nils m fields)))))))
+


### PR DESCRIPTION
* present in `0.10.*`

The data from the installed addon, like `description`, is overwritten by `nil` values when it leaves the database if it wasn't present in the catalogue. In fact, it looks like installed data is being supplanted entirely by the catalogue data after a match has been made.

- [x] tests
- [x] review