### PR TITLE
adds curseforge and wowinterface source parsing in .toc files

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -25,6 +25,14 @@ see CHANGELOG.md for a more formal list of changes by release
 * remove dependency cheshire
     - clojure.data.json does all we need
     - done
+* add support for reconciling addons by 'x-curse' and 'x-wowi' ids
+    - example: https://github.com/ascott18/TellMeWhen/blob/master/TellMeWhen.toc#L19-L20
+* add a 'addons dir' to the test helper
+    - lots of boilerplate around this in core_test.clj
+        - investigate this 
+    - presence of an addon dir skitches about ~6 tests
+    - I have replaced the manual app starting with the 'with-running-app' wrapper though
+    - and explicit 'add-addon-dir!' isn't so bad
 
 ### todo
 
@@ -33,25 +41,27 @@ see CHANGELOG.md for a more formal list of changes by release
     - tests pass
     - readme updated
     - release updated
-* add a 'addons dir' to the test helper
-    - lots of boilerplate around this in core_test.clj
-        - investigate this 
-* add support for reconciling addons by 'x-curse' and 'x-wowi' ids
-    - example: https://github.com/ascott18/TellMeWhen/blob/master/TellMeWhen.toc#L19-L20
 * import/export, capture game track of exported addon dir?
 * import/export, export user catalogue
 * github, installation from github via import menu not updating log until finished
     - this is an async issue
-* wowman-data, stop publishing a 'daily' release
-    - we have multiple catalogs now
-    - 0.10.0 uses the raw catalog files directly
-    - 0.9.2 was still using the daily release
-    - remove the 'daily' release after 0.11.0 is released
 * remove debugging? mode
 * gui, scroll tabs with mouse
 
 ## todo bucket (no particular order)
 
+* move location of catalogs into user settings
+    - allow user to specify their own catalogs
+        - a url to a catalog that is downloaded and included while loading up the db
+        - different from the 'user catalog'
+    - wowman-data, stop publishing a 'daily' release
+        - we have multiple catalogs now
+        - 0.10.0 uses the raw catalog files directly
+        - 0.9.2 was still using the daily release
+        - remove the 'daily' release after 0.11.0 is released
+        - this will break older releases but users who prefer older versions of the software shouldn't be stranded if the catalog goes away
+            - they should just be able to plug in a new location of the catalog
+            - unfortunately *these* users will be out of luck, but future users won't be
 * greater parallelism
     - internal job queue
     - replace log at bottom of screen with a list of jobs being processed and how far along they are
@@ -94,9 +104,7 @@ see CHANGELOG.md for a more formal list of changes by release
     - I don't mind my colours but not everybody may
     - my colours don't work very well on native lnf + dark themes:
         - https://github.com/ogri-la/wowman/issues/105
-* allow user to specify their own catalogs
-    - a url to a catalog that is downloaded and included while loading up the db
-    - different from the 'user catalog'
+
 * when curseforge api is down users get a wall of red error messages with very little useful information
     - see issue 91: https://github.com/ogri-la/wowman/issues/91
         - the error message has been improved but we still get a red wall of text

--- a/TODO.md
+++ b/TODO.md
@@ -27,6 +27,7 @@ see CHANGELOG.md for a more formal list of changes by release
     - done
 * add support for reconciling addons by 'x-curse' and 'x-wowi' ids
     - example: https://github.com/ascott18/TellMeWhen/blob/master/TellMeWhen.toc#L19-L20
+    - done
 * add a 'addons dir' to the test helper
     - lots of boilerplate around this in core_test.clj
         - investigate this 

--- a/TODO.md
+++ b/TODO.md
@@ -33,6 +33,7 @@ see CHANGELOG.md for a more formal list of changes by release
     - presence of an addon dir skitches about ~6 tests
     - I have replaced the manual app starting with the 'with-running-app' wrapper though
     - and explicit 'add-addon-dir!' isn't so bad
+    - done
 
 ### todo
 

--- a/TODO.md
+++ b/TODO.md
@@ -22,6 +22,9 @@ see CHANGELOG.md for a more formal list of changes by release
 * remove dependency data.codec
     - this can be done with native java
     - done
+* remove dependency cheshire
+    - clojure.data.json does all we need
+    - done
 
 ### todo
 

--- a/src/wowman/specs.clj
+++ b/src/wowman/specs.clj
@@ -36,7 +36,7 @@
 ;; minimum needed to be scraped from a toc file
 (s/def ::toc
   (s/keys :req-un [::name ::label ::description ::dirname ::interface-version ::installed-version]
-          :opt [::group-id ::primary? ::group-addons]))
+          :opt [::group-id ::primary? ::group-addons ::source ::source-id]))
 
 ;; the result of merging an installed addon (toc) with an installable addon from the catalogue
 (s/def ::toc-addon-summary
@@ -100,6 +100,8 @@
 (s/def ::catalog-updated-date ::ymd-dt)
 (def catalog-sources #{"curseforge" "wowinterface" "github" "tukui" "tukui-classic"})
 (s/def ::catalog-source catalog-sources)
+(s/def ::catalog-source-id (s/or ::integer-id? int? ;; tukui has negative ids
+                                 ::string-id? string?))
 (s/def ::zoned-dt-obj #(instance? java.time.ZonedDateTime %))
 (s/def ::download-count (s/and int? #(>= % 0)))
 (s/def ::donation-uri (s/nilable ::uri))
@@ -160,6 +162,7 @@
 
 (s/def ::export-type #{:json :edn})
 (s/def ::source ::catalog-source) ;; alias :(
+(s/def ::source-id ::catalog-source-id) ;; alias :(
 (s/def ::export-record (s/keys :req-un [::name]
                                :opt [::source]))
 (s/def ::export-record-list (s/coll-of ::export-record))

--- a/src/wowman/toc.clj
+++ b/src/wowman/toc.clj
@@ -126,6 +126,14 @@
         alias (when (contains? aliases label)
                 {:alias (get aliases label)})
 
+        wowi-source (when-let [x-wowi-id (-> nfo-contents :x-wow-id utils/to-int)] 
+                      {:source "wowinterface"
+                       :source-id x-wowi-id})
+
+        curse-source (when-let [x-curse-id (-> nfo-contents :x-curse-project-id utils/to-int)]
+                       {:source "curseforge"
+                        :source-id x-curse-id})
+
         addon {:name (normalise-name label)
                :dirname dirname
                :label label
@@ -141,7 +149,9 @@
                ;;:required-dependencies (:requireddeps keyvals)
                }
 
-        addon (merge alias addon)]
+        ;; yes, this prefers curseforge over wowinterface.
+        ;; I need to figure out some way of supporting multiple hosts per-addon
+        addon (merge addon alias wowi-source curse-source)]
 
     ;; if source present but is not in list of known sources, ignore the nfo-contents
     (if (and (contains? nfo-contents :source)

--- a/src/wowman/toc.clj
+++ b/src/wowman/toc.clj
@@ -126,11 +126,11 @@
         alias (when (contains? aliases label)
                 {:alias (get aliases label)})
 
-        wowi-source (when-let [x-wowi-id (-> nfo-contents :x-wow-id utils/to-int)]
+        wowi-source (when-let [x-wowi-id (-> keyvals :x-wowi-id utils/to-int)]
                       {:source "wowinterface"
                        :source-id x-wowi-id})
 
-        curse-source (when-let [x-curse-id (-> nfo-contents :x-curse-project-id utils/to-int)]
+        curse-source (when-let [x-curse-id (-> keyvals :x-curse-project-id utils/to-int)]
                        {:source "curseforge"
                         :source-id x-curse-id})
 

--- a/src/wowman/toc.clj
+++ b/src/wowman/toc.clj
@@ -108,6 +108,13 @@
   ;; todo, replace this with a slugify fn
   (-> label lower-case rm-trailing-version (replace ":" "") (replace " " "-") (replace "\\?" "")))
 
+;;
+
+(defn-spec merge-toc-nfo ::sp/toc
+  "merges nfo data over toc data, nothing more"
+  [toc ::sp/toc, nfo (s/nilable ::sp/nfo)]
+  (merge toc nfo))
+
 (defn-spec parse-addon-toc ::sp/toc
   [addon-dir ::sp/extant-dir, keyvals map?]
   (let [dirname (fs/base-name addon-dir) ;; /foo/bar/baz => baz
@@ -159,7 +166,7 @@
       addon
 
       ;; otherwise, merge the addon with the nfo contents
-      (merge addon nfo-contents))))
+      (merge-toc-nfo addon nfo-contents))))
 
 (defn-spec blizzard-addon? boolean?
   "returns `true` if given path looks like an official Blizzard addon"

--- a/src/wowman/toc.clj
+++ b/src/wowman/toc.clj
@@ -126,7 +126,7 @@
         alias (when (contains? aliases label)
                 {:alias (get aliases label)})
 
-        wowi-source (when-let [x-wowi-id (-> nfo-contents :x-wow-id utils/to-int)] 
+        wowi-source (when-let [x-wowi-id (-> nfo-contents :x-wow-id utils/to-int)]
                       {:source "wowinterface"
                        :source-id x-wowi-id})
 

--- a/test/wowman/core_test.clj
+++ b/test/wowman/core_test.clj
@@ -8,6 +8,7 @@
    ;;[taoensso.timbre :as log :refer [debug info warn error spy]]
    [wowman
     [main :as main]
+    [toc :as toc]
     [catalog :as catalog]
     [utils :as utils]
     [test-helper :as helper :refer [fixture-path helper-data-dir with-running-app]]
@@ -331,7 +332,7 @@
                      :source-id 0}
 
                 ;; the nfo data is simply merged over the top of the scraped toc data
-                toc (merge toc nfo) ;; todo: defer to app logic
+                toc (toc/merge-toc-nfo toc nfo)
 
                 ;; we then attempt to match this 'toc+nfo' to an addon in the catalog
                 catalog-match (core/-db-match-installed-addons-with-catalog [toc])

--- a/test/wowman/core_test.clj
+++ b/test/wowman/core_test.clj
@@ -277,7 +277,7 @@
             (core/refresh) ;; re-read the installation directory
             (is (= expected (core/get-state :installed-addon-list)))))))))
 
-(deftest check-for-update
+(deftest check-for-addon-update
   (testing "the key :update? is set on an addon when there is a difference between the installed version of an addon and it's matching catalog version"
 
     (let [;; we start off with a list of these called a catalog. it's downloaded from github


### PR DESCRIPTION
* `X-WoWI-ID` and `X-Curse-Project-ID` are now detected in `.toc` files and used during reconcilation

- [x] tests
- [x] review