### PR TITLE
ignore certain addons 

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -91,6 +91,7 @@ see CHANGELOG.md for a more formal list of changes by release
     - our 'theme' solution is too naive
         - we should be deferring to the current theme for highlighted colours
         - how?
+            - https://pirlwww.lpl.arizona.edu/resources/guide/software/SwingX/org/jdesktop/swingx/plaf/UIColorHighlighterAddon.html
 * bug, changing sort order during refresh doesn't reflect which addon is being updated
     - I think changing column ordering and moving columns should be disabled while updates happen
         - just freeze or disable them or something.

--- a/src/wowman/core.clj
+++ b/src/wowman/core.clj
@@ -34,6 +34,8 @@
   {:notice/error :tomato
    :notice/warning :lemonchiffon
    ;;:installed/unmatched :tomato
+   :installed/ignored-bg :lightgray
+   :installed/ignored-fg :darkgray
    :installed/needs-updating :lemonchiffon
    :installed/hovering "#e6e6e6" ;; light grey
    :search/already-installed "#99bc6b" ;; greenish
@@ -44,6 +46,8 @@
   {:notice/error "#009CB8"
    :notice/warning "#000532"
    ;;:installed/unmatched :tomato
+   :installed/ignored-bg :darkgray
+   :installed/ignored-fg :lightgray
    :installed/needs-updating "#000532"
    :installed/hovering "#191919"
    :search/already-installed "#664394"

--- a/src/wowman/core.clj
+++ b/src/wowman/core.clj
@@ -497,8 +497,13 @@
   ([addon ::sp/addon-or-toc-addon, install-dir ::sp/extant-dir]
    (install-addon-guard addon install-dir false))
   ([addon ::sp/addon-or-toc-addon, install-dir ::sp/extant-dir, test-only? boolean?]
-   (if (not (fs/writeable? install-dir)) ;; todo: is this checked on startup?
-     (error "failed to install addon, directory not writeable" install-dir)
+   (cond
+     ;; do some pre-installation checks
+     (:ignore? addon) (warn "failing to install addon, addon is being ignored:" install-dir)
+     (not (fs/writeable? install-dir)) (error "failing to install addon, directory not writeable:" install-dir)
+
+     :else ;; attempt downloading and installing addon
+
      (let [downloaded-file (download-addon addon install-dir)
            bad-zipfile-msg (format "failed to read zip file '%s', could not install %s" downloaded-file (:name addon))
            bad-addon-msg (format "refusing to install '%s'. It contains top-level files or top-level directories missing .toc files."  (:name addon))]

--- a/src/wowman/core.clj
+++ b/src/wowman/core.clj
@@ -34,7 +34,7 @@
   {:notice/error :tomato
    :notice/warning :lemonchiffon
    ;;:installed/unmatched :tomato
-   :installed/ignored-bg :lightgray
+   :installed/ignored-bg nil
    :installed/ignored-fg :darkgray
    :installed/needs-updating :lemonchiffon
    :installed/hovering "#e6e6e6" ;; light grey
@@ -46,8 +46,8 @@
   {:notice/error "#009CB8"
    :notice/warning "#000532"
    ;;:installed/unmatched :tomato
-   :installed/ignored-bg :darkgray
-   :installed/ignored-fg :lightgray
+   :installed/ignored-bg nil
+   :installed/ignored-fg "#666666"
    :installed/needs-updating "#000532"
    :installed/hovering "#191919"
    :search/already-installed "#664394"

--- a/src/wowman/main.clj
+++ b/src/wowman/main.clj
@@ -72,7 +72,10 @@
   (try
     (logging/change-log-level :debug)
     (if ns-kw
-      (if (some #{ns-kw} [:core :http :main :toc :utils :curseforge-api :zip :catalog :cli :gui :wowinterface :wowinterface-api :github-api :tukui-api :config])
+      (if (some #{ns-kw} [:main :utils :http
+                          :core :toc :nfo :zip :config :catalog
+                          :cli :gui
+                          :curseforge-api :wowinterface :wowinterface-api :github-api :tukui-api])
         (if fn-kw
           ;; `test-vars` will run the test but not give feedback if test passes OR test not found
           ;; slightly better than nothing

--- a/src/wowman/nfo.clj
+++ b/src/wowman/nfo.clj
@@ -66,8 +66,9 @@
   ""
   [install-dir ::sp/extant-dir, dirname string?]
   (let [nfo-file-contents (read-nfo-file install-dir dirname)
-        ;; `ignore?` is never written to file, although the user can put it there manually if they like
+        ;; `ignore?` is never written to file, although the user can put it there manually if they like.
         ;; this value may also be introduced in `toc.clj`
         ignore-flag (when (ignore? (join install-dir dirname))
+                      (warn (format "ignoring addon '%s': addon directory contains a SVC sub-directory (.git/.hg/.svn etc)" dirname))
                       {:ignore? true})]
     (merge nfo-file-contents ignore-flag)))

--- a/src/wowman/nfo.clj
+++ b/src/wowman/nfo.clj
@@ -10,24 +10,26 @@
    [me.raynes.fs :as fs]))
 
 (comment
-  "a '.wowman.json' file is written when an addon is installed or updated. 
+  "a '.wowman.json' (nfo) file is written when an addon is installed or updated. 
   It serves to fill in any blank spots in our knowledge of the addon.
   The file can be safely deleted but some addons may fail to find a match 
-  in the catalogue again and will need to be found and re-installed.")
+  in the catalogue and will need to be found and re-installed.")
+
+(def nfo-filename ".wowman.json")
 
 (def ignorable-dir-set #{".git" ".hg" ".svn"})
 
 (defn-spec ignore? boolean?
-  "return true if addon looks like it's under version control"
+  "returns true if addon looks like it's under version control"
   [path ::sp/extant-dir]
   (let [sub-dirs (->> path fs/list-dir (filter fs/directory?) (map fs/base-name) (mapv str))]
     (not (nil? (some ignorable-dir-set sub-dirs)))))
 
 (defn-spec derive ::sp/nfo
-  "extract fields from the addon data that will be written to the `.wowman.json` file"
+  "extract fields from the addon data that will be written to the nfo file"
   [addon ::sp/addon-or-toc-addon, primary? boolean?]
-  {;; important! as an addon is (re)installed the addon :installed-version scraped from the .toc file is replaced with the :version from the catalog
-   ;; later, when comparing installed addons against the catalog, the comparisons will be more consistent
+  {;; important! as an addon is updated or installed, the `:installed-version` from the .toc file is overridden by the `:version` online
+   ;; later, when comparing installed addons against the catalogue, the comparisons will be more consistent
    :installed-version (:version addon)
    :name (:name addon) ;; normalised name. once used to match to online addon, we now use source+source-id
    :group-id (:uri addon) ;; groups all of an addon's directories together. this is a verbose but natural way of specifying source+source-id
@@ -38,7 +40,7 @@
 (defn-spec nfo-path ::sp/file
   "given an installation directory and the directory name of an addon, return the absolute path to the nfo file"
   [install-dir ::sp/extant-dir, dirname string?]
-  (join install-dir dirname ".wowman.json")) ;; /path/to/Addons/AddonName/.wowman.json
+  (join install-dir dirname nfo-filename)) ;; /path/to/addons/AddonName/.wowman.json
 
 (defn-spec write-nfo ::sp/extant-file
   "given an installation directory and an addon, extract the neccessary bits and write them to a nfo file"
@@ -48,13 +50,14 @@
     path))
 
 (defn-spec rm-nfo nil?
+  "deletes a nfo file and only a nfo file"
   [path ::sp/extant-file]
-  (when (= ".wowman.json" (fs/base-name path))
+  (when (= nfo-filename (fs/base-name path))
     (fs/delete path)
     nil))
 
 (defn-spec read-nfo-file (s/or :ok ::sp/nfo, :error nil?)
-  "reads the .wowman.json file. 
+  "reads the nfo file. 
   failure to load the json results in the file being deleted. 
   failure to validate the json data results in the file being deleted."
   [install-dir ::sp/extant-dir, dirname string?]
@@ -68,17 +71,16 @@
                                  :data-spec ::sp/nfo)))
 
 (defn-spec read-nfo (s/or :ok ::sp/nfo, :error nil?)
+  "reads and parses the contents of the .nfo file and checks if addon should be ignored or not"
   [install-dir ::sp/extant-dir, dirname string?]
   (let [nfo-file-contents (read-nfo-file install-dir dirname)
         ;; `ignore?` is never written to file, although the user can put it there manually if they like.
-        ;; if `ignore?` is present in the nfo file it overrides our nfo and toc file checks
+        ;; if `ignore?` is present in the nfo file it overrides the nfo and toc file checks.
         ;; this value may also be introduced in `toc.clj`
         user-ignored (contains? nfo-file-contents :ignore?)
-        _ (when (and user-ignored
-                     (:ignore? nfo-file-contents))
+        _ (when (and user-ignored (:ignore? nfo-file-contents))
             (warn (format "addon '%s' is being manually ignored" dirname)))
 
-        ;; ignore addon because of SVC dir, but only check if :ignore not found in nfo file
         ignore-flag (when (and (not user-ignored)
                                (ignore? (join install-dir dirname)))
                       (warn (format "ignoring addon '%s': addon directory contains a SVC sub-directory (.git/.hg/.svn etc)" dirname))

--- a/src/wowman/specs.clj
+++ b/src/wowman/specs.clj
@@ -113,8 +113,11 @@
 
 ;;
 
-(s/def ::nfo (s/keys :req-un [::installed-version ::name ::group-id ::primary? ::source ::source-id]
-                     :opt [::ignore?]))
+(s/def ::ignore-flag (s/keys :req-un [::ignore?]))
+
+(s/def ::nfo (s/or :dev-addon-missing-nfo ::ignore-flag
+                   :ok (s/keys :req-un [::installed-version ::name ::group-id ::primary? ::source ::source-id]
+                               :opt [::ignore?])))
 
 ;; orphaned
 (s/def ::file-byte-array-pair (s/cat :file ::file

--- a/src/wowman/specs.clj
+++ b/src/wowman/specs.clj
@@ -77,7 +77,7 @@
 (s/def ::description (s/nilable string?))
 (s/def ::matched? boolean?)
 (s/def ::group-id string?)
-(s/def ::primary boolean?)
+(s/def ::primary? boolean?)
 (s/def ::group-addons ::toc-list)
 (s/def ::version string?)
 (s/def ::installed-version (s/nilable ::version))
@@ -111,7 +111,10 @@
 (s/def ::string-pair (s/and (s/coll-of string?) #(= (count %) 2)))
 (s/def ::list-of-string-pairs (s/coll-of ::string-pair))
 
-(s/def ::nfo map?) ;; todo: not cool
+;;
+
+(s/def ::nfo (s/keys :req-un [::installed-version ::name ::group-id ::primary? ::source ::source-id]
+                     :opt [::ignore?]))
 
 ;; orphaned
 (s/def ::file-byte-array-pair (s/cat :file ::file
@@ -129,6 +132,7 @@
 (s/def ::selected-catalog keyword?)
 (s/def ::gui-theme #{:light :dark})
 (s/def ::user-config (s/keys :req-un [::addon-dir-list ::selected-catalog ::gui-theme]))
+(s/def ::ignore? boolean?)
 
 (s/def ::reason-phrase (s/and string? #(<= (count %) 50)))
 (s/def ::status int?) ;; a little too general but ok for now

--- a/src/wowman/toc.clj
+++ b/src/wowman/toc.clj
@@ -123,7 +123,7 @@
 
         ;; https://github.com/ogri-la/wowman/issues/47 - user encountered addon sans 'Title' attribute
         ;; if a match in the catalog is found even after munging the title, it will overwrite this one
-        no-label-label (str dirname) ;; "EveryAddon"
+        no-label-label (str dirname " *") ;; "EveryAddon *"
         label (:title keyvals)
         label (if-not (empty? label) label no-label-label)
         _ (when (= label no-label-label)
@@ -144,8 +144,9 @@
         tukui-source (when-let [x-tukui-id (-> keyvals :x-tukui-projectid utils/to-int)]
                        {:source "tukui"
                         :source-id x-tukui-id})
-        
+
         ignore-flag (when (some->> keyvals :version (clojure.string/includes? "@project-version@"))
+                      (warn (format "ignoring addon '%s': 'Version' field in .toc file is unrendered" dirname))
                       {:ignore? true})
 
         addon {:name (normalise-name label)

--- a/src/wowman/toc.clj
+++ b/src/wowman/toc.clj
@@ -145,7 +145,9 @@
                        {:source "tukui"
                         :source-id x-tukui-id})
 
-        ignore-flag (when (some->> keyvals :version (clojure.string/includes? "@project-version@"))
+        user-ignored (contains? nfo-contents :ignore?)
+        ignore-flag (when (and (not user-ignored)
+                               (some->> keyvals :version (clojure.string/includes? "@project-version@")))
                       (warn (format "ignoring addon '%s': 'Version' field in .toc file is unrendered" dirname))
                       {:ignore? true})
 

--- a/src/wowman/toc.clj
+++ b/src/wowman/toc.clj
@@ -123,7 +123,7 @@
 
         ;; https://github.com/ogri-la/wowman/issues/47 - user encountered addon sans 'Title' attribute
         ;; if a match in the catalog is found even after munging the title, it will overwrite this one
-        no-label-label (str dirname " *") ;; "EveryAddon *"
+        no-label-label (str dirname) ;; "EveryAddon"
         label (:title keyvals)
         label (if-not (empty? label) label no-label-label)
         _ (when (= label no-label-label)
@@ -141,6 +141,13 @@
                        {:source "curseforge"
                         :source-id x-curse-id})
 
+        tukui-source (when-let [x-tukui-id (-> keyvals :x-tukui-projectid utils/to-int)]
+                       {:source "tukui"
+                        :source-id x-tukui-id})
+        
+        ignore-flag (when (some->> keyvals :version (clojure.string/includes? "@project-version@"))
+                      {:ignore? true})
+
         addon {:name (normalise-name label)
                :dirname dirname
                :label label
@@ -156,9 +163,9 @@
                ;;:required-dependencies (:requireddeps keyvals)
                }
 
-        ;; yes, this prefers curseforge over wowinterface.
+        ;; yes, this prefers curseforge over wowinterface. and tukui over all others.
         ;; I need to figure out some way of supporting multiple hosts per-addon
-        addon (merge addon alias wowi-source curse-source)]
+        addon (merge addon alias wowi-source curse-source tukui-source ignore-flag)]
 
     ;; if source present but is not in list of known sources, ignore the nfo-contents
     (if (and (contains? nfo-contents :source)

--- a/src/wowman/ui/gui.clj
+++ b/src/wowman/ui/gui.clj
@@ -378,7 +378,7 @@
 
         highlighter (org.jdesktop.swingx.decorator.ColorHighlighter.
                      predicate
-                     (seesaw.color/color bg-colour)
+                     (when bg-colour (seesaw.color/color bg-colour))
                      (when fg-colour (seesaw.color/color fg-colour)))]
     (.addHighlighter grid highlighter)
     nil))
@@ -491,9 +491,13 @@
                            (nil? (.getValue adapter (find-column-by-label grid "matched?"))))
 
         addon-ignored? (fn [adapter]
-                         (->> (find-column-by-label grid "ignore?") (.getValue adapter) (= true)))
+                         (->> (find-column-by-label grid "ignore?") (.getValue adapter) true?))
 
-        addon-needs-update? #(true? (.getValue % (find-column-by-label grid "update?")))
+        addon-needs-update? (fn [adapter]
+                              (if (addon-ignored? adapter)
+                                false
+                                (->> (find-column-by-label grid "update?") (.getValue adapter) true?)))
+
         date-renderer #(when % (-> % clojure.instant/read-instant-date (utils/fmt-date "yyyy-MM-dd")))
         iface-version-renderer #(when % (-> % str utils/interface-version-to-game-version))
 
@@ -523,7 +527,6 @@
       (add-highlighter grid addon-unmatched? (colours :installed/unmatched)))
 
     (add-highlighter grid addon-ignored? (colours :installed/ignored-bg) (colours :installed/ignored-fg))
-
     (add-highlighter grid addon-needs-update? (colours :installed/needs-updating))
     (add-cell-renderer grid "updated" date-renderer)
     (add-cell-renderer grid "WoW" iface-version-renderer)

--- a/src/wowman/ui/gui.clj
+++ b/src/wowman/ui/gui.clj
@@ -491,7 +491,7 @@
                            (nil? (.getValue adapter (find-column-by-label grid "matched?"))))
 
         addon-ignored? (fn [adapter]
-                         (->> (find-column-by-label grid "ignore?") (.getValue adapter) nil? not))
+                         (->> (find-column-by-label grid "ignore?") (.getValue adapter) (= true)))
 
         addon-needs-update? #(true? (.getValue % (find-column-by-label grid "update?")))
         date-renderer #(when % (-> % clojure.instant/read-instant-date (utils/fmt-date "yyyy-MM-dd")))

--- a/src/wowman/ui/gui.clj
+++ b/src/wowman/ui/gui.clj
@@ -464,21 +464,22 @@
 (defn installed-addons-panel
   []
   (let [;; always visible when debugging and always available from the column menu
-        hidden-by-default-cols [:addon-id :group-id :primary? :update? :matched? :categories :downloads :updated]
-        tblmdl (sstbl/table-model :columns [{:key :name :text "addon-id"}
+        hidden-by-default-cols [:addon-id :group-id :primary? :update? :matched? :ignore? :categories :downloads :updated]
+        tblmdl (sstbl/table-model :columns [{:key :name, :text "addon-id"}
                                             :group-id
                                             :primary?
                                             :update?
                                             :matched?
-                                            {:key :uri :text "go"}
-                                            {:key :label :text "name"}
+                                            :ignore?
+                                            {:key :uri, :text "go"}
+                                            {:key :label, :text "name"}
                                             :description
-                                            {:key :installed-version :text "installed"}
-                                            {:key :version :text "available"}
-                                            {:key :download-count :text "downloads" :class Integer}
-                                            {:key :updated-date :text "updated"}
-                                            {:key :interface-version :text "WoW"}
-                                            {:key :category-list :text "categories"}]
+                                            {:key :installed-version, :text "installed"}
+                                            {:key :version, :text "available"}
+                                            {:key :download-count, :text "downloads" :class Integer}
+                                            {:key :updated-date, :text "updated"}
+                                            {:key :interface-version, :text "WoW"}
+                                            {:key :category-list, :text "categories"}]
                                   :rows [])
 
         grid (x/table-x :id :tbl-installed-addons

--- a/test/wowman/core_test.clj
+++ b/test/wowman/core_test.clj
@@ -252,7 +252,6 @@
                            :version "v8.2.0-v1.13.2-7135.139",
                            :dirname "EveryAddon",
                            :primary? true,
-                           :ignore? false
                            :matched? true}
 
                           {:description "Does what every addon does, just better",
@@ -273,7 +272,6 @@
                            :version "v8.2.0-v1.13.2-7135.139",
                            :dirname "EveryOtherAddon",
                            :primary? true,
-                           :ignore? false
                            :matched? true}]]
 
             (core/import-exported-file output-path)
@@ -335,7 +333,6 @@
                            :version "v8.2.0-v1.13.2-7135.139",
                            :dirname "EveryAddon",
                            :primary? true,
-                           :ignore? false,
                            :matched? true}
 
                           {:description "Does what every addon does, just better",
@@ -356,7 +353,6 @@
                            :version "v8.2.0-v1.13.2-7135.139",
                            :dirname "EveryOtherAddon",
                            :primary? true,
-                           :ignore? false
                            :matched? true}]]
 
             (core/import-exported-file output-path)

--- a/test/wowman/core_test.clj
+++ b/test/wowman/core_test.clj
@@ -252,6 +252,7 @@
                            :version "v8.2.0-v1.13.2-7135.139",
                            :dirname "EveryAddon",
                            :primary? true,
+                           :ignore? false
                            :matched? true}
 
                           {:description "Does what every addon does, just better",
@@ -272,6 +273,7 @@
                            :version "v8.2.0-v1.13.2-7135.139",
                            :dirname "EveryOtherAddon",
                            :primary? true,
+                           :ignore? false
                            :matched? true}]]
 
             (core/import-exported-file output-path)
@@ -333,6 +335,7 @@
                            :version "v8.2.0-v1.13.2-7135.139",
                            :dirname "EveryAddon",
                            :primary? true,
+                           :ignore? false,
                            :matched? true}
 
                           {:description "Does what every addon does, just better",
@@ -353,6 +356,7 @@
                            :version "v8.2.0-v1.13.2-7135.139",
                            :dirname "EveryOtherAddon",
                            :primary? true,
+                           :ignore? false
                            :matched? true}]]
 
             (core/import-exported-file output-path)

--- a/test/wowman/nfo_test.clj
+++ b/test/wowman/nfo_test.clj
@@ -47,12 +47,12 @@
 
 (deftest nfo-path
   (testing "path to the nfo file is generated correctly"
-    (let [expected (utils/join (addon-path) ".wowman.json")]
+    (let [expected (utils/join (addon-path) nfo/nfo-filename)]
       (is (= expected (nfo/nfo-path (install-dir) addon-dir))))))
 
 (deftest rm-nfo
   (testing "a nfo file is deleted"
-    (let [path (utils/join (addon-path) ".wowman.json")]
+    (let [path (utils/join (addon-path) nfo/nfo-filename)]
       (fs/touch path)
       (is (fs/exists? path))
       (nfo/rm-nfo path)
@@ -82,7 +82,7 @@
                     :source "wowinterface"
                     :source-id 123}
           expected nfo-data]
-      (spit (utils/join (addon-path) ".wowman.json") (utils/to-json nfo-data))
+      (spit (utils/join (addon-path) nfo/nfo-filename) (utils/to-json nfo-data))
       (is (= expected (nfo/read-nfo (install-dir) addon-dir)))))
 
   (testing "an addon with nfo data AND an ignorable sub-directory is parsed correctly"
@@ -93,7 +93,7 @@
                     :source "wowinterface"
                     :source-id 123}
           expected (assoc nfo-data :ignore? true)]
-      (spit (utils/join (ignorable-addon-path) ".wowman.json") (utils/to-json nfo-data))
+      (spit (utils/join (ignorable-addon-path) nfo/nfo-filename) (utils/to-json nfo-data))
       (is (= expected (nfo/read-nfo (install-dir) ignorable-addon-dir)))))
 
   (testing "an addon with nfo data, an ignorable sub-directory AND an ignore flag, is parsed correctly"
@@ -108,6 +108,6 @@
                     ;; this is only ever set by the user, not by the app.
                     :ignore? false}
           expected (assoc nfo-data :ignore? false)]
-      (spit (utils/join (ignorable-addon-path) ".wowman.json") (utils/to-json nfo-data))
+      (spit (utils/join (ignorable-addon-path) nfo/nfo-filename) (utils/to-json nfo-data))
       (is (= expected (nfo/read-nfo (install-dir) ignorable-addon-dir))))))
 

--- a/test/wowman/nfo_test.clj
+++ b/test/wowman/nfo_test.clj
@@ -1,0 +1,113 @@
+(ns wowman.nfo-test
+  (:require
+   [clojure.test :refer [deftest testing is use-fixtures]]
+   [wowman
+    [utils :as utils]
+    [nfo :as nfo]
+    [test-helper :as helper]]
+   [wowman.utils :refer [join]]
+   [me.raynes.fs :as fs]))
+
+(def addon-dir "SomeAddon")
+(def ignorable-addon-dir "SomeOtherAddon")
+
+(defn install-dir
+  []
+  (str fs/*cwd*))
+
+(defn addon-path
+  []
+  (utils/join fs/*cwd* addon-dir))
+
+(defn ignorable-addon-path
+  []
+  (utils/join fs/*cwd* ignorable-addon-dir))
+
+;;
+
+(defn fixture-someaddon
+  [f]
+  (fs/mkdir addon-dir)
+  (fs/mkdirs (utils/join ignorable-addon-dir ".git"))
+  (f))
+
+(use-fixtures :each helper/fixture-tempcwd fixture-someaddon)
+
+;;
+
+(deftest ignore-dir
+  (testing "an addon directory is ignored if it contains an svc-type sub directory"
+    (doseq [ignorable-dir nfo/ignorable-dir-set
+            :let [path (utils/join (addon-path) ignorable-dir)]]
+      (try
+        (fs/mkdirs path)
+        (is (nfo/ignore? (addon-path)))
+        (finally
+          (fs/delete-dir (addon-path)))))))
+
+(deftest nfo-path
+  (testing "path to the nfo file is generated correctly"
+    (let [expected (utils/join (addon-path) ".wowman.json")]
+      (is (= expected (nfo/nfo-path (install-dir) addon-dir))))))
+
+(deftest rm-nfo
+  (testing "a nfo file is deleted"
+    (let [path (utils/join (addon-path) ".wowman.json")]
+      (fs/touch path)
+      (is (fs/exists? path))
+      (nfo/rm-nfo path)
+      (is (not (fs/exists? path)))))
+
+  (testing "a non-nfo file is preserved"
+    (let [path (utils/join (addon-path) "SomeAddon.toc")]
+      (fs/touch path)
+      (is (fs/exists? path))
+      (nfo/rm-nfo path)
+      (is (fs/exists? path)))))
+
+(deftest read-nfo
+  (testing "an addon with no nfo data returns nothing"
+    (let [expected nil]
+      (is (= expected (nfo/read-nfo (install-dir) addon-dir)))))
+
+  (testing "an addon with no nfo data but an ignorable sub-directory returns the 'ignore flag'"
+    (let [expected {:ignore? true}]
+      (is (= expected (nfo/read-nfo (install-dir) ignorable-addon-dir)))))
+
+  (testing "an addon with nfo data is parsed correctly"
+    (let [nfo-data {:installed-version "1.0"
+                    :name "someaddon"
+                    :group-id "blah"
+                    :primary? true
+                    :source "wowinterface"
+                    :source-id 123}
+          expected nfo-data]
+      (spit (utils/join (addon-path) ".wowman.json") (utils/to-json nfo-data))
+      (is (= expected (nfo/read-nfo (install-dir) addon-dir)))))
+
+  (testing "an addon with nfo data AND an ignorable sub-directory is parsed correctly"
+    (let [nfo-data {:installed-version "1.0"
+                    :name "someaddon"
+                    :group-id "blah"
+                    :primary? true
+                    :source "wowinterface"
+                    :source-id 123}
+          expected (assoc nfo-data :ignore? true)]
+      (spit (utils/join (ignorable-addon-path) ".wowman.json") (utils/to-json nfo-data))
+      (is (= expected (nfo/read-nfo (install-dir) ignorable-addon-dir)))))
+
+  (testing "an addon with nfo data, an ignorable sub-directory AND an ignore flag, is parsed correctly"
+    (let [nfo-data {:installed-version "1.0"
+                    :name "someaddon"
+                    :group-id "blah"
+                    :primary? true
+                    :source "wowinterface"
+                    :source-id 123
+
+                    ;; update me! destroy any changes to my work!
+                    ;; this is only ever set by the user, not by the app.
+                    :ignore? false}
+          expected (assoc nfo-data :ignore? false)]
+      (spit (utils/join (ignorable-addon-path) ".wowman.json") (utils/to-json nfo-data))
+      (is (= expected (nfo/read-nfo (install-dir) ignorable-addon-dir))))))
+

--- a/test/wowman/toc_test.clj
+++ b/test/wowman/toc_test.clj
@@ -95,22 +95,21 @@ SomeAddon.lua")
 
   (testing "parsing scraped keyvals in .toc value yields expected values"
     (let [;; all of this can be derived from the directory name and sensible defaults
-          base-case {:name "everyaddon"
+          base-case {:name "everyaddon-*"
                      :dirname "EveryAddon"
-                     :label "EveryAddon"
+                     :label "EveryAddon *"
                      :description nil
                      :interface-version 80200
                      :installed-version nil}
-          
+
           cases [;; empty/no title
                  [{:title ""} base-case]
                  [{:title nil} base-case]
 
                  ;; addon is in development
                  [{:version "@project-version@"} (merge base-case
-                                                        {:installed-version "@project-version@" 
-                                                         :ignore? true})]
-                 ]
+                                                        {:installed-version "@project-version@"
+                                                         :ignore? true})]]
           install-dir fs/*cwd*
           addon-dir (utils/join install-dir "EveryAddon")]
       (fs/mkdir addon-dir)

--- a/test/wowman/toc_test.clj
+++ b/test/wowman/toc_test.clj
@@ -94,24 +94,23 @@ SomeAddon.lua")
       (is (= expected (toc/parse-addon-toc-guard addon-path)))))
 
   (testing "parsing scraped keyvals in .toc value yields expected values"
-    (let [cases [[{"title" ""} {:name "everyaddon-*",
-                                :dirname "EveryAddon",
-                                :label "EveryAddon *",
-                                :description nil,
-                                :interface-version 80200,
-                                :installed-version nil}]
-                 [{"Title" ""} {:name "everyaddon-*",
-                                :dirname "EveryAddon",
-                                :label "EveryAddon *",
-                                :description nil,
-                                :interface-version 80200,
-                                :installed-version nil}]
-                 [{"Title" nil} {:name "everyaddon-*",
-                                 :dirname "EveryAddon",
-                                 :label "EveryAddon *",
-                                 :description nil,
-                                 :interface-version 80200,
-                                 :installed-version nil}]]
+    (let [;; all of this can be derived from the directory name and sensible defaults
+          base-case {:name "everyaddon"
+                     :dirname "EveryAddon"
+                     :label "EveryAddon"
+                     :description nil
+                     :interface-version 80200
+                     :installed-version nil}
+          
+          cases [;; empty/no title
+                 [{:title ""} base-case]
+                 [{:title nil} base-case]
+
+                 ;; addon is in development
+                 [{:version "@project-version@"} (merge base-case
+                                                        {:installed-version "@project-version@" 
+                                                         :ignore? true})]
+                 ]
           install-dir fs/*cwd*
           addon-dir (utils/join install-dir "EveryAddon")]
       (fs/mkdir addon-dir)

--- a/test/wowman/toc_test.clj
+++ b/test/wowman/toc_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.test :refer [deftest testing is use-fixtures]]
    [wowman
+    [nfo :as nfo]
     [utils :as utils]
     [toc :as toc]
     [test-helper :as helper]]
@@ -136,7 +137,7 @@ SomeAddon.lua")
           addon-dir (utils/join install-dir "EveryAddon")]
 
       (fs/mkdir addon-dir)
-      (spit (utils/join addon-dir ".wowman.json") (utils/to-json nfo-data))
+      (spit (utils/join addon-dir nfo/nfo-filename) (utils/to-json nfo-data))
       (is (= expected (toc/parse-addon-toc addon-dir toc-data))))))
 
 (deftest rm-trailing-version


### PR DESCRIPTION
- [x] presence of SVC sub-directory ignores addon
- [x] presence of unrendered `version` field in `.toc` file ignores addon
- [x] ignore column available to select in the GUI
- [x] warnings in console when addon is being ignored
- [x] ignored rows are clearly highlighted - greyed out or something
- [x] user can manually ignore addon by futzing with the ~.toc~ `.wowman.json` file
- [x] tests
- [x] review