### PR TITLE
separate toc and nfo modules

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,6 +8,14 @@ see CHANGELOG.md for a more formal list of changes by release
 
 ### done
 
+* code refactor
+    - diagram state transitions
+        - my mental model has become fuzzy
+        - done, see strongbox-docs
+    - untable nfo and toc files
+        - result of diagramming modules
+        - done
+
 ### todo
 
 * rename wowman
@@ -52,8 +60,6 @@ see CHANGELOG.md for a more formal list of changes by release
     * core.clj is getting too large
         - it's difficult to navigate and debug
         - many tests are accumulating in core_test.clj
-    * diagram state transitions
-        - my mental model has become fuzzy
 
 * catalog updates
     * rename references of 'uri' to 'url'

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -565,7 +565,6 @@
     (swap! state assoc :installed-addon-list installed-addon-list)
     nil))
 
-;; TODO: test, now that it is it's own thing.
 (defn-spec group-addons ::sp/toc-list
   "an addon may actually be many addons bundled together in a single download.
   strongbox tags the bundled addons as they are unzipped and tries to determine the primary one.
@@ -604,7 +603,7 @@
 
 (defn-spec -load-installed-addons ::sp/toc-list
   "reads the .toc files from the given addon dir, reads any nfo data for 
-  these addons and returns the mooshed data"
+  these addons, groups them, returns the mooshed data"
   [addon-dir ::sp/addon-dir]
   (let [addon-list (strongbox.toc/installed-addons addon-dir)
 
@@ -635,8 +634,7 @@
     (group-addons addon-list)))
 
 (defn-spec load-installed-addons nil?
-  "reads the .toc files from the currently selected addon dir, reads any nfo data for 
-  these addons, mooshes them together and updates application state"
+  "guard function. offloads the hard work to `-load-installed-addons` then updates application state"
   []
   (if-let [addon-dir (get-state :selected-addon-dir)]
     (let [addon-list (-load-installed-addons addon-dir)]

--- a/test/strongbox/core_test.clj
+++ b/test/strongbox/core_test.clj
@@ -9,7 +9,6 @@
    [strongbox
     [zip :as zip]
     [main :as main]
-    [toc :as toc]
     [nfo :as nfo]
     [catalog :as catalog]
     [utils :as utils]
@@ -436,7 +435,7 @@
                      :source-id 0}
 
                 ;; the nfo data is simply merged over the top of the scraped toc data
-                toc (toc/merge-toc-nfo toc nfo)
+                toc (merge toc nfo)
 
                 ;; we then attempt to match this 'toc+nfo' to an addon in the catalog
                 catalog-match (core/-db-match-installed-addons-with-catalog [toc])

--- a/test/strongbox/core_test.clj
+++ b/test/strongbox/core_test.clj
@@ -571,13 +571,6 @@
 
 (deftest load-installed-addons
   (testing "regular .toc file can be loaded"
-
-    ;; test0: toc data and missing nfo data are handled
-    ;; test1: toc data and nfo data are mooshed together as expected
-    ;; test2: ignore-flag in nfo data overrides toc data ignore flag correctly
-    ;; test3: invalid nfo data is not merged
-
-    ;; test0
     (let [addon-dir (str fs/*cwd*)
           some-addon-path (utils/join addon-dir "SomeAddon")
           _ (fs/mkdirs some-addon-path)
@@ -609,7 +602,6 @@
           _ (fs/mkdirs some-addon-path)
 
           some-addon-toc (utils/join some-addon-path "SomeAddon.toc")
-
           _ (spit some-addon-toc "## Title: SomeAddon\n## Description: asdf\n## Interface: 80300\n## Version: 1.2.3")
 
           some-addon-nfo (utils/join some-addon-path nfo/nfo-filename)
@@ -638,13 +630,10 @@
       (is (= expected (core/-load-installed-addons addon-dir))))))
 
 (deftest group-addons
-  ;; 4. synthetic records
-
   (testing "addons with nothing to group on are not modified"
     (let [addon-list [{:name "a1", :dirname "A1", :label "A1", :description "" :interface-version 80300 :installed-version "1.2.3"}
                       {:name "a2", :dirname "A2", :label "A2", :description "" :interface-version 80300 :installed-version "4.5.6"}
                       {:name "a3", :dirname "A3", :label "A2", :description "" :interface-version 80300 :installed-version "7.8.9"}]
-          ;; 
           expected addon-list]
       (is (= expected (core/group-addons addon-list)))))
 
@@ -655,7 +644,6 @@
                        :group-id "bar" :primary? true}
                       {:name "a3", :dirname "A3", :label "A2", :description "" :interface-version 80300 :installed-version "7.8.9"
                        :group-id "baz" :primary? true}]
-          ;; 
           expected addon-list]
       (is (= expected (core/group-addons addon-list)))))
 

--- a/test/strongbox/toc_test.clj
+++ b/test/strongbox/toc_test.clj
@@ -2,7 +2,6 @@
   (:require
    [clojure.test :refer [deftest testing is use-fixtures]]
    [strongbox
-    [nfo :as nfo]
     [utils :as utils]
     [toc :as toc]
     [test-helper :as helper]]
@@ -117,28 +116,29 @@ SomeAddon.lua")
       (doseq [[toc-data expected] cases]
         (is (= expected (toc/parse-addon-toc addon-dir toc-data))))))
 
-  (testing "parsing scraped keyvals in .toc with an explicitly set ignore flag in nfo file"
-    (let [base-case {:name "everyaddon-*"
-                     :dirname "EveryAddon"
-                     :label "EveryAddon *"
-                     :description nil
-                     :interface-version 80200}
+  (comment "toc and nfo modules are now separate. this test needs to live in core"
+           (testing "parsing scraped keyvals in .toc with an explicitly set ignore flag in nfo file"
+             (let [base-case {:name "everyaddon-*"
+                              :dirname "EveryAddon"
+                              :label "EveryAddon *"
+                              :description nil
+                              :interface-version 80200}
 
           ;; addon is in development
-          toc-data {:version "@project-version@"}
+                   toc-data {:version "@project-version@"}
 
-          nfo-data {;; update me! destroy any changes to my work!
+                   nfo-data {;; update me! destroy any changes to my work!
                     ;; this is only ever set by the user, not by the app.
-                    :ignore? false}
+                             :ignore? false}
 
-          expected (merge base-case nfo-data {:installed-version "@project-version@"})
+                   expected (merge base-case nfo-data {:installed-version "@project-version@"})
 
-          install-dir fs/*cwd*
-          addon-dir (utils/join install-dir "EveryAddon")]
+                   install-dir fs/*cwd*
+                   addon-dir (utils/join install-dir "EveryAddon")]
 
-      (fs/mkdir addon-dir)
-      (spit (utils/join addon-dir nfo/nfo-filename) (utils/to-json nfo-data))
-      (is (= expected (toc/parse-addon-toc addon-dir toc-data))))))
+               (fs/mkdir addon-dir)
+               (spit (utils/join addon-dir nfo/nfo-filename) (utils/to-json nfo-data))
+               (is (= expected (toc/parse-addon-toc addon-dir toc-data)))))))
 
 (deftest rm-trailing-version
   (testing "parsing of 'Title' attribute in toc file"

--- a/test/strongbox/toc_test.clj
+++ b/test/strongbox/toc_test.clj
@@ -114,31 +114,7 @@ SomeAddon.lua")
           addon-dir (utils/join install-dir "EveryAddon")]
       (fs/mkdir addon-dir)
       (doseq [[toc-data expected] cases]
-        (is (= expected (toc/parse-addon-toc addon-dir toc-data))))))
-
-  (comment "toc and nfo modules are now separate. this test needs to live in core"
-           (testing "parsing scraped keyvals in .toc with an explicitly set ignore flag in nfo file"
-             (let [base-case {:name "everyaddon-*"
-                              :dirname "EveryAddon"
-                              :label "EveryAddon *"
-                              :description nil
-                              :interface-version 80200}
-
-          ;; addon is in development
-                   toc-data {:version "@project-version@"}
-
-                   nfo-data {;; update me! destroy any changes to my work!
-                    ;; this is only ever set by the user, not by the app.
-                             :ignore? false}
-
-                   expected (merge base-case nfo-data {:installed-version "@project-version@"})
-
-                   install-dir fs/*cwd*
-                   addon-dir (utils/join install-dir "EveryAddon")]
-
-               (fs/mkdir addon-dir)
-               (spit (utils/join addon-dir nfo/nfo-filename) (utils/to-json nfo-data))
-               (is (= expected (toc/parse-addon-toc addon-dir toc-data)))))))
+        (is (= expected (toc/parse-addon-toc addon-dir toc-data)))))))
 
 (deftest rm-trailing-version
   (testing "parsing of 'Title' attribute in toc file"


### PR DESCRIPTION
* toc no longer depends on nfo.
* toc+nfo merging logic moved into core

- [x] I've broken the grouping mechanism. it was using nfo data to determine this
- [x] review
