### PR TITLE
categories to tags

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -80,12 +80,11 @@ see CHANGELOG.md for a more formal list of changes by release
     - publish a 'strongbox-catalogue' repo
         - just like wowman-data, but for strongbox
 
-    - can game-track-list be included from all other hosts?
-        - not just wowi?
-            - even wowi is broken though
-            - I've seen a reference to a v4 of their 'api' that should be investigated
-                - naming changes mostly so far
-            - I've also noticed switches in game tracks for some of their addons this week (2020-03)
+    - remove 'updated' date
+        - should have been removed when updating catalogues was removed
+    
+    - bumps spec version of catalogue to 2
+        - keep wowman-coercer but dispatch based off of spec version
 
 * bug, test fixtures for user-config had their :catalog value renamed to :catalogue
         - revert those changes
@@ -104,10 +103,19 @@ see CHANGELOG.md for a more formal list of changes by release
 * database, investigate a datalog backed datastore
     - https://clojure.github.io/clojure-contrib/doc/datalog.html
     - https://github.com/tonsky/datascript
+    - crux is working out elsewhere
     - I want addons loaded *quickly*
     - I want to *query* addons *quickly*
 
 ## todo bucket (no particular order)
+
+* game track list in catalogue
+    - can game-track-list be included from all other hosts?
+        - not just wowi?
+            - even wowi is broken though
+            - I've seen a reference to a v4 of their 'api' that should be investigated
+                - naming changes mostly so far
+            - I've also noticed switches in game tracks for some of their addons this week (2020-03)
 
 * EOL planning
     - I'm not going away and neither is strongbox, but! *should* I or my free time disappear will strongbox continue being useful?
@@ -116,7 +124,7 @@ see CHANGELOG.md for a more formal list of changes by release
                 - more can be done around this to make catalogue generation more accessible and safe
         - what can't I control?
             - addon hosts
-                - our interface with them is their API or, in wowi's case, their API and website
+                - our interface with them is their API or in wowi's case, their API and website
         
 * code refactor
     * simplify `install-addon` interface in core.clj

--- a/src/strongbox/catalogue.clj
+++ b/src/strongbox/catalogue.clj
@@ -35,7 +35,7 @@
 ;;
 
 (defn-spec format-catalogue-data ::sp/catalogue
-  "formats given catalogue data"
+  "formats given catalogue data" ;; todo: this is a bad docstr
   [addon-list ::sp/addon-summary-list, created-date ::sp/catalogue-created-date, updated-date ::sp/catalogue-updated-date]
   (let [addon-list (mapv #(into (omap/ordered-map) (sort %))
                          (sort-by :name addon-list))]

--- a/src/strongbox/catalogue.clj
+++ b/src/strongbox/catalogue.clj
@@ -8,6 +8,7 @@
    [taoensso.timbre :as log :refer [debug info warn error spy]]
    [java-time]
    [strongbox
+    [tags :as tags]
     [utils :as utils :refer [todt utcnow]]
     [specs :as sp]
     [tukui-api :as tukui-api]
@@ -61,7 +62,7 @@
                              new-row (if (contains? new-row :category-list)
                                        (-> new-row
                                            (clojure.set/rename-keys {:category-list :tag-list})
-                                           (update-in [:tag-list] utils/category-list-to-tag-list))
+                                           (update-in [:tag-list] (partial tags/category-list-to-tag-list (:source new-row))))
                                        new-row)]
 
                          new-row))]

--- a/src/strongbox/catalogue.clj
+++ b/src/strongbox/catalogue.clj
@@ -35,7 +35,7 @@
 ;;
 
 (defn-spec format-catalogue-data ::sp/catalogue
-  "formats given catalogue data" ;; todo: this is a bad docstr
+  "returns a correctly formatted catalogue given a list of addons and a created and updated date"
   [addon-list ::sp/addon-summary-list, created-date ::sp/catalogue-created-date, updated-date ::sp/catalogue-updated-date]
   (let [addon-list (mapv #(into (omap/ordered-map) (sort %))
                          (sort-by :name addon-list))]

--- a/src/strongbox/catalogue.clj
+++ b/src/strongbox/catalogue.clj
@@ -52,10 +52,20 @@
     (let [row-coerce (fn [row]
                        (let [new-row (-> row
                                          (clojure.set/rename-keys {:uri :url})
-                                         (dissoc :alt-name))]
-                         (if (contains? new-row :description)
-                           (update-in new-row [:description] utils/safe-subs 255)
-                           new-row)))]
+                                         (dissoc :alt-name))
+
+                             new-row (if (contains? new-row :description)
+                                       (update-in new-row [:description] utils/safe-subs 255)
+                                       new-row)
+
+                             new-row (if (contains? new-row :category-list)
+                                       (-> new-row
+                                           (clojure.set/rename-keys {:category-list :tag-list})
+                                           (update-in [:tag-list] utils/category-list-to-tag-list))
+                                       new-row)]
+
+                         new-row))]
+
       (update-in catalogue-data [:addon-summary-list] (partial mapv row-coerce)))))
 
 (defn read-catalogue

--- a/src/strongbox/catalogue.clj
+++ b/src/strongbox/catalogue.clj
@@ -8,7 +8,6 @@
    [taoensso.timbre :as log :refer [debug info warn error spy]]
    [java-time]
    [strongbox
-    ;;[core :as core]
     [utils :as utils :refer [todt utcnow]]
     [specs :as sp]
     [tukui-api :as tukui-api]
@@ -145,95 +144,6 @@
 
 ;;
 
-(defn-spec -merge-curse-wowi-catalogues ::sp/catalogue
-  [aa ::sp/catalogue, ab ::sp/catalogue]
-  (let [;; this is 80% sanity check, 20% correctness
-        ab (assoc ab :addon-summary-list (de-dupe-wowinterface (:addon-summary-list ab)))
-
-        addon-list (into (:addon-summary-list aa)
-                         (:addon-summary-list ab))
-        _ (info "total addons:" (count addon-list))
-
-        addon-groups (group-by :name addon-list)
-        _ (info "total unique addons:" (count addon-groups))
-
-        ;; addons that appear in both catalogues
-        multiple-sources (filter (fn [[_ group-list]]
-                                   (> (count group-list) 1)) addon-groups)
-        _ (info "total overlap:" (count multiple-sources) "(addons)" (count (flatten (vals multiple-sources))) "(entries)")
-
-        ;; drop those addons that appear in multiple catalogues
-        ;; they get some additional filtering
-        multiple-sources-key-set (set (keys multiple-sources))
-        ;; (this takes ages, there must be a faster way to remove ~1k rows from ~10k results)
-        addon-list (remove #(some #{(:name %)} multiple-sources-key-set) addon-list)
-        ;;_ (info "addons sans multiples:" (count addon-list))
-
-        ;; todo: move this to shorten-catalogue
-        ;; when there is a very large gap between updated-dates, drop one addon in favour of the other
-        ;; at time of writing:
-        ;; - filtering for > 2 years removes  231 of the 2356 addons overlapping, leaving 2125 addons appearing in both catalogues
-        ;; - filtering for > 1 year removes   338 of the 2356 addons overlapping, leaving 2018 addons appearing in both catalogues
-        ;; - filtering for > 6 months removes 389 of the 2356 addons overlapping, leaving 1967 addons appearing in both catalogues
-        ;; - filtering for > 1 month removes  471 of the 2356 addons overlapping, leaving 1885 addons appearing in both catalogues
-        drop-some-addons (mapv (fn [[_ group-list]]
-
-                                 ;; sanity check. it's definitely possible for an addon to appear more than twice
-                                 (when (> (count group-list) 2)
-                                   ;; huh, was expecting more than none
-                                   ;; there should have been groupings *within* wowinterface ...
-                                   ;; but if those groupings don't appear in curseforge, then that would make sense.
-                                   ;; update: definitely the case after checking the duplicates within wowinterface.
-                                   (error "addon has more than 2 entries in group:" (:name (first group-list)) (count group-list)))
-
-                                 (let [[aa ab] (take 2 (sort-by #(-> % :description count) group-list)) ;; :description is nil for wowinterface
-                                       adt (todt (:updated-date aa)) ;; wowinterface
-                                       bdt (todt (:updated-date ab)) ;; curseforge (probably)
-                                       diff (java-time/duration adt bdt)
-                                       neg? (java-time/negative? diff)
-                                       diff-days (java-time/as diff :days)
-                                       diff-days (if neg? (- diff-days) diff-days)
-                                       ;;threshold (* 365 2) ;; two years
-                                       ;;threshold (/ 366 2) ;; six-ish months
-                                       threshold 28 ;; 1 moonth. if an addon author hasn't updated both hosts within four weeks, then one is preferred over the other
-                                       ]
-                                   (if (> diff-days threshold)
-                                     ;; if the diff is negative, that means B (curseforge) is older than A (wowinterface)
-                                     (if neg?
-                                       [aa]
-                                       [ab])
-                                     [aa ab])))
-                               multiple-sources)
-        filtered-group-addons (flatten drop-some-addons)
-        _ (info "duplicate addons pruned after filtering for age:" (- (count (flatten (vals multiple-sources)))
-                                                                      (count filtered-group-addons)))
-
-        addon-list (into addon-list filtered-group-addons)
-        _ (info "final addon count" (count addon-list) (format "(%s survived duplicate pruning)" (count filtered-group-addons)))
-
-        today (utcnow)
-        update-addon (fn [a]
-                       (let [dtobj (java-time/zoned-date-time (:updated-date a))
-                             age-in-days (java-time/as (java-time/duration dtobj today) :days)
-                             version-age (condp #(< %2 %1) age-in-days
-                                           7 :brand-new ;; < 1 week old
-                                           42 :new      ;; 1-6 weeks old
-                                           168 :recent  ;; 6 weeks-6 months old (28*6)
-                                           504 :aging   ;; 6-18 months old (28*18)
-                                           :ancient)
-
-                             ;; todo: normalise categories here
-                             ]
-                         (merge a {:age version-age})))
-        addon-list (mapv update-addon addon-list)
-
-        ;; should these two dates belong to the catalogue proper or derived from the component catalogues?
-        ;; lets go with derived for now
-        created-date (first (sort [(:datestamp aa) (:datestamp ab)])) ;; earliest of the two catalogues
-        updated-date (last (sort [(:updated-datestamp aa) (:updated-datestamp ab)]))] ;; most recent of the two catalogues
-
-    (format-catalogue-data addon-list created-date updated-date)))
-
 (defn-spec shorten-catalogue (s/or :ok ::sp/catalogue, :problem nil?)
   [full-catalogue-path ::sp/extant-file]
   (let [{:keys [addon-summary-list datestamp]}
@@ -250,12 +160,6 @@
                           (java-time/before? dtobj release-of-previous-expansion)))]
     (when addon-summary-list
       (format-catalogue-data (remove unmaintained? addon-summary-list) datestamp datestamp))))
-
-(defn-spec merge-curse-wowi-catalogues ::sp/catalogue
-  [curseforge-catalogue ::sp/extant-file, wowinterface-catalogue ::sp/extant-file]
-  (let [aa (utils/load-json-file curseforge-catalogue)
-        ab (utils/load-json-file wowinterface-catalogue)]
-    (-merge-curse-wowi-catalogues aa ab)))
 
 ;;
 

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -194,12 +194,16 @@
 
 (def select-*-catalogue (str (static-slurp "resources/query--all-catalogue.sql") " ")) ;; trailing space is important
 
-(defn-spec db-split-category-list vector?
+(defn-spec db-split-tag-list vector?
   "converts a pipe-separated list of categories into a vector"
-  [category-list-str (s/nilable string?)]
-  (if (empty? category-list-str)
+  [tag-list-str (s/nilable string?)]
+  (if (empty? tag-list-str)
     []
-    (clojure.string/split category-list-str #"\|")))
+    (as-> tag-list-str $
+      (clojure.string/split $ #"\|")
+      (map keyword $)
+      (sort $)
+      (vec $))))
 
 (defn db-gen-game-track-list
   "converts the 'retail_track' and 'classic_track' boolean values in db into a list of strings"
@@ -223,13 +227,14 @@
       source-id)))
 
 (defn db-coerce-catalogue-values
-  "further per-row processing of catalogue data after retrieving it from the database"
+  "further per-row processing of catalogue data *after* retrieving it from the database"
   [row]
   (when row
-    (->> row
-         (utils/coerce-map-values {:source-id db-preserve-integer-source-id-if-possible
-                                   :category-list db-split-category-list})
-         (db-gen-game-track-list))))
+    (as-> row $
+      (utils/coerce-map-values {:source-id db-preserve-integer-source-id-if-possible
+                                :category-list db-split-tag-list} $)
+      (clojure.set/rename-keys $ {:category-list :tag-list})
+      (db-gen-game-track-list $))))
 
 (defn db-search
   "searches database for addons whose name or description contains given user input.
@@ -248,10 +253,18 @@
 
 (defn query-db
   "like `get-state`, uses 'paths' (keywords) to do predefined queries"
-  [kw]
+  [kw & [arg-list]]
   (case kw
     :addon-summary-list (->> (db-query select-*-catalogue) (mapv db-coerce-catalogue-values))
     :catalogue-size (-> "select count(*) as num from catalogue" db-query first :num)
+    :addon-by-source-and-name (as-> select-*-catalogue q,
+                                (str q "WHERE source = ? AND name = ?")
+                                (db-query q :arg-list arg-list)
+                                (mapv db-coerce-catalogue-values q))
+    :addon-by-name (as-> select-*-catalogue $,
+                     (str $ "WHERE name = ?")
+                     (db-query $ :arg-list arg-list)
+                     (mapv db-coerce-catalogue-values $))
 
     nil))
 
@@ -841,9 +854,9 @@
   (let [ds (get-db)
         {:keys [addon-summary-list]} catalogue-data
 
-        addon-categories (mapv (fn [{:keys [source-id source category-list]}]
-                                 (mapv (fn [category]
-                                         [source-id source category]) category-list)) addon-summary-list)
+        addon-categories (mapv (fn [{:keys [source-id source tag-list]}]
+                                 (mapv (fn [tag]
+                                         [source-id source (name tag)]) tag-list)) addon-summary-list)
 
         ;; using `set` was a symptom of a problem with duplicate categories affecting curseforge
         ;; I think it's safest to leave it in for now
@@ -853,7 +866,7 @@
         category-list (->> addon-categories (mapv rest) set vec)
 
         xform-row (fn [row]
-                    (let [ignored [:category-list :age :game-track-list :created-date]
+                    (let [ignored [:tag-list :age :game-track-list :created-date]
                           mapping {:source-id :source_id
                                    :download-count :download_count
                                    ;;:created-date :created_date ;; curseforge only and unused
@@ -1069,13 +1082,22 @@
 ;; created to investigate some performance issues, seems sensible to keep it separate
 (defn -mk-import-idx
   [addon-list]
-  (let [key-fn #(select-keys % [:source :name])
-        addon-summary-list (query-db :addon-summary-list)
-        ;; todo: this sucks. use a database
-        catalogue-idx (group-by key-fn addon-summary-list)
-        find-expand (fn [addon]
-                      (when-let [matching-addon (first (get catalogue-idx (key-fn addon)))]
-                        (expand-summary-wrapper matching-addon)))
+  (let [find-expand (fn [addon]
+                      (let [{:keys [source name]} addon
+                            matching-addon
+                            (cond
+                              ;; first by given name and source. hopefully 0 or 1 results
+                              (and source name) (first (query-db :addon-by-source-and-name [source name]))
+
+                              ;; first addon by given name. potentially multiple results
+                              name (first (query-db :addon-by-name [name]))
+
+                              ;; we have nothing to query on :(                          
+                              :else nil)]
+                        (when matching-addon
+                          (expand-summary-wrapper matching-addon))))
+
+                      ;;(when-let [matching-addon (first (get catalogue-idx (key-fn addon)))]
         matching-addon-list (->> addon-list (map find-expand) (remove nil?) vec)]
     matching-addon-list))
 

--- a/src/strongbox/curseforge_api.clj
+++ b/src/strongbox/curseforge_api.clj
@@ -123,7 +123,8 @@
    :description (:summary snippet)
    ;; sorting cuts down on noise in diffs.
    ;; `set` because of curseforge duplicate categories
-   :category-list (->> snippet :categories (map :name) set sort vec)
+   ;; 2020-03: disabled in favour of :tag-list
+   ;;:category-list (->> snippet :categories (map :name) set sort vec)
    :tag-list (->> snippet :categories (map :name) utils/category-list-to-tag-list)
    :created-date (:dateCreated snippet) ;; omg *yes*. perfectly formed dates
    ;; we now have :dateModified and :dateReleased to pick from

--- a/src/strongbox/curseforge_api.clj
+++ b/src/strongbox/curseforge_api.clj
@@ -1,6 +1,7 @@
 (ns strongbox.curseforge-api
   (:require
    [strongbox
+    [tags :as tags]
     [http :as http]
     [specs :as sp]
     [utils :as utils :refer [to-int to-json fmap join from-epoch to-url]]]
@@ -125,7 +126,7 @@
    ;; `set` because of curseforge duplicate categories
    ;; 2020-03: disabled in favour of :tag-list
    ;;:category-list (->> snippet :categories (map :name) set sort vec)
-   :tag-list (->> snippet :categories (map :name) utils/category-list-to-tag-list)
+   :tag-list (->> snippet :categories (map :name) (tags/category-list-to-tag-list "curseforge"))
    :created-date (:dateCreated snippet) ;; omg *yes*. perfectly formed dates
    ;; we now have :dateModified and :dateReleased to pick from
    ;;:updated-date (:dateModified snippet)

--- a/src/strongbox/curseforge_api.clj
+++ b/src/strongbox/curseforge_api.clj
@@ -124,6 +124,7 @@
    ;; sorting cuts down on noise in diffs.
    ;; `set` because of curseforge duplicate categories
    :category-list (->> snippet :categories (map :name) set sort vec)
+   :tag-list (->> snippet :categories (map :name) utils/category-list-to-tag-list)
    :created-date (:dateCreated snippet) ;; omg *yes*. perfectly formed dates
    ;; we now have :dateModified and :dateReleased to pick from
    ;;:updated-date (:dateModified snippet)

--- a/src/strongbox/github_api.clj
+++ b/src/strongbox/github_api.clj
@@ -194,7 +194,9 @@
             :name (slugify repo "")
             :download-count download-count
             :game-track-list (or (find-gametracks-toc-data source-id) [])
-            :category-list []}
+            ;; 2020-03: disabled in favour of :tag-list
+            ;;:category-list []
+            :tag-list []}
 
            ;; 'something' failed to parse :(
            ;; would love a way to pass back a more specific error

--- a/src/strongbox/main.clj
+++ b/src/strongbox/main.clj
@@ -73,7 +73,7 @@
   (try
     (logging/change-log-level :debug)
     (if ns-kw
-      (if (some #{ns-kw} [:main :utils :http :specs
+      (if (some #{ns-kw} [:main :utils :http :specs :tags
                           :core :toc :nfo :zip :config :catalogue
                           :cli :gui
                           :curseforge-api :wowinterface :wowinterface-api :github-api :tukui-api])

--- a/src/strongbox/specs.clj
+++ b/src/strongbox/specs.clj
@@ -40,13 +40,14 @@
 
 
 (s/def ::tag keyword?)
-(s/def ::tag-list (s/coll-of ::tag))
+(s/def ::tag-list (s/or :ok (s/coll-of ::tag)
+                        :empty ::empty-coll))
 
 ;; addon data that comes from the catalogue
 
 
 (s/def ::addon-summary
-  (s/keys :req-un [::url ::name ::label ::category-list ::updated-date ::download-count ::source ::source-id]
+  (s/keys :req-un [::url ::name ::label ::tag-list ::updated-date ::download-count ::source ::source-id]
           :opt [::description ;; wowinterface summaries have no description
                 ::created-date ;; wowinterface summaries have no created date
                 ::game-track-list ;; more of a set, really

--- a/src/strongbox/specs.clj
+++ b/src/strongbox/specs.clj
@@ -38,6 +38,10 @@
 
 ;;
 
+
+(s/def ::tag keyword?)
+(s/def ::tag-list (s/coll-of ::tag))
+
 ;; addon data that comes from the catalogue
 
 

--- a/src/strongbox/tags.clj
+++ b/src/strongbox/tags.clj
@@ -8,10 +8,8 @@
    ;;[taoensso.timbre :refer [debug info warn error spy]]
    ))
 
-;; wowinterface-specific categories that are replaced
-
-
 (def wowi-replacements
+  "wowinterface-specific categories that are replaced"
   {"Character Advancement" [:quests :leveling :achievements]
    "Other" [:misc]
    "Suites" [:compilations]
@@ -32,20 +30,16 @@
    "Tradeskill Mods" [:tradeskill]
    "Classic - General" [:classic]})
 
-;; wowinterface-specific categories that gain new tags
-
-
 (def wowi-supplements
+  "wowinterface-specific categories that gain new tags"
   {"Pets" [:battle-pets :companions]
    "Data Broker" [:data]
    "Titan Panel" [:plugins]
    "FuBar" [:plugins]
    "Mail" [:ui]})
 
-;; curseforge-specific categories that are replaced
-
-
 (def curse-replacements
+  "curseforge-specific categories that are replaced"
   {"HUDs" [:ui :unit-frames]
    "Minigames" [:mini-games]
    "Auction & Economy" [:action-house]
@@ -56,10 +50,8 @@
    "Boss Encounters" [:boss]
    "Twitch Integration" []})
 
-;; curseforge-specific categories that gain new tags
-
-
 (def curse-supplements
+  "curseforge-specific categories that gain new tags"
   {"Quests & Leveling" [:achievements]
    "Arena" [:pvp]
    "Battleground" [:pvp]
@@ -71,6 +63,7 @@
    "Titan Panel" [:plugins]})
 
 (def tukui-replacements
+  "tukui-specific categories that are replaced"
   {"Edited UIs & Compilations" [:ui :compilations]
    "Full UI Replacements" [:ui]
    "Skins" [:ui]
@@ -78,18 +71,15 @@
    "Plugins: Other" [:plugins :misc]})
 
 (def tukui-supplements
+  "tukui-specific categories that gain new tags"
   {"Map & Minimap" [:coords :ui]})
 
-;; categories shared by all addon hosts already that are replaced
-
-
 (def general-replacements
+  "categories shared by all addon hosts already that are replaced"
   {"Miscellaneous" [:misc]})
 
-;; categories shared by all addon hosts that gain new tags
-
-
 (def general-supplements
+  "categories shared by all addon hosts that gain new tags"
   {"Druid" [:class]
    "Warlock" [:class]
    "Warrior" [:class]
@@ -137,9 +127,7 @@
     (-> category
         lower-case
         trim
-
-        ;; hyphenate white space
-        (clojure.string/replace #" +" "-")
+        (clojure.string/replace #" +" "-") ;; hyphenate white space
         keyword)))
 
 (defn-spec category-to-tag-list (s/or :singluar ::sp/tag, :composite ::sp/tag-list)
@@ -148,17 +136,15 @@
   (let [replacements (merge general-replacements (get replacement-map addon-host))
         supplements (merge general-supplements (get supplement-map addon-host))
 
-        ;; if there is a replacement set of tags, we don't continue searching for supplementary tags
         replacement-tags (get replacements category [])
         supplementary-tags (get supplements category [])
 
         tag-list (into replacement-tags supplementary-tags)]
-
     (if-not (empty? replacement-tags)
       ;; we found a set of replacement tags so we're done
       tag-list
 
-      ;; couldn't find a replacement set of tags so parse the category
+      ;; couldn't find a replacement set of tags so parse the category string
       (let [bits (clojure.string/split category #"( & |, |: )+")]
         (->> bits (map category-to-tag) (into tag-list) (remove nil?) vec)))))
 
@@ -166,7 +152,7 @@
   "given a list of category strings, converts them into a distinct list of tags by calling `category-to-tag-list`."
   [addon-host ::sp/catalogue-source, category-list ::sp/category-list]
   ;; sorting cuts down on noise in diffs.
-  ;; `set` because curseforge has duplicate categories
+  ;; `set` because curseforge has duplicate categories and supplemental tags may introduce duplicates
   (->> category-list (map (partial category-to-tag-list addon-host)) flatten set sort vec))
 
 ;;

--- a/src/strongbox/tags.clj
+++ b/src/strongbox/tags.clj
@@ -1,0 +1,174 @@
+(ns strongbox.tags
+  (:require
+   [strongbox.specs :as sp]
+   [clojure.string :refer [trim lower-case]]
+   [clojure.spec.alpha :as s]
+   [orchestra.core :refer [defn-spec]]
+   [orchestra.spec.test :as st]
+   ;;[taoensso.timbre :refer [debug info warn error spy]]
+   ))
+
+;; wowinterface-specific categories that are replaced
+
+
+(def wowi-replacements
+  {"Character Advancement" [:quests :leveling :achievements]
+   "Other" [:misc]
+   "Suites" [:compilations]
+   "Graphic UI Mods" [:ui :ui-replacements]
+   "UI Media" [:ui] ;; audio video ?
+   "ROFL" [:misc :mini-games]
+   "Combat Mods" [:combat]
+   "Buff, Debuff, Spell" [:buffs :debuffs]
+   "Casting Bars, Cooldowns" [:buffs :debuffs :ui]
+   "Map, Coords, Compasses" [:map :minimap :coords :ui]
+   "RolePlay, Music Mods" [:role-play :audio]
+   "Chat Mods" [:chat]
+   "Unit Mods" [:unit-frames]
+   "Raid Mods" [:unit-frames :raid-frames]
+   "Data Mods" [:data]
+   "Utility Mods" [:utility] ;; misc?
+   "Action Bar Mods" [:action-bars :ui]
+   "Tradeskill Mods" [:tradeskill]
+   "Classic - General" [:classic]})
+
+;; wowinterface-specific categories that gain new tags
+
+
+(def wowi-supplements
+  {"Pets" [:battle-pets :companions]
+   "Data Broker" [:data]
+   "Titan Panel" [:plugins]
+   "FuBar" [:plugins]
+   "Mail" [:ui]})
+
+;; curseforge-specific categories that are replaced
+
+
+(def curse-replacements
+  {"HUDs" [:ui :unit-frames]
+   "Minigames" [:mini-games]
+   "Auction & Economy" [:action-house]
+   "Chat & Communication" [:chat]
+   "Development Tools" [:dev]
+   "Libraries" [:libs]
+   "Damage Dealer" [:dps]
+   "Boss Encounters" [:boss]
+   "Twitch Integration" []})
+
+;; curseforge-specific categories that gain new tags
+
+
+(def curse-supplements
+  {"Quests & Leveling" [:achievements]
+   "Arena" [:pvp]
+   "Battleground" [:pvp]
+   "Battle Pets" [:pets :companions :mounts]
+   "Map & Minimap" [:coords :ui]
+   "Raid Frames" [:unit-frames]
+   "Data Export" [:data]
+   "Data Broker" [:data]
+   "Titan Panel" [:plugins]})
+
+(def tukui-replacements
+  {"Edited UIs & Compilations" [:ui :compilations]
+   "Full UI Replacements" [:ui]
+   "Skins" [:ui]
+   "Tooltips" [:tooltip] ;; singular
+   "Plugins: Other" [:plugins :misc]})
+
+(def tukui-supplements
+  {"Map & Minimap" [:coords :ui]})
+
+;; categories shared by all addon hosts already that are replaced
+
+
+(def general-replacements
+  {"Miscellaneous" [:misc]})
+
+;; categories shared by all addon hosts that gain new tags
+
+
+(def general-supplements
+  {"Druid" [:class]
+   "Warlock" [:class]
+   "Warrior" [:class]
+   "Rogue" [:class]
+   "Healers" [:role]
+   "Death Knight" [:class]
+   "Paladin" [:class]
+   "Mage" [:class :caster]
+   "Priest" [:class :caster]
+   "Tank" [:class]
+   "Monk" [:class]
+   "Shaman" [:class :caster]
+   "Demon Hunter" [:class]
+   "Hunter" [:class]
+
+   "Alchemy" [:professions]
+   "Cooking" [:professions]
+   "Mining" [:professions]
+   "Engineering" [:professions]
+   "Jewelcrafting" [:professions]
+   "Tailoring" [:professions]
+   "First Aid" [:professions]
+   "Fishing" [:professions]
+   "Leatherworking" [:professions]
+   "Enchanting" [:professions]
+   "Blacksmithing" [:professions]
+   "Inscription" [:professions]
+   "Skinning" [:professions]
+   "Archaeology" [:professions]
+   "Herbalism" [:professions]})
+
+(def replacement-map
+  {"wowinterface" wowi-replacements
+   "curseforge" curse-replacements
+   "tukui" tukui-replacements})
+
+(def supplement-map
+  {"wowinterface" wowi-supplements
+   "curseforge" curse-supplements
+   "tukui" tukui-supplements})
+
+(defn-spec category-to-tag (s/or :ok ::sp/tag, :bad nil?)
+  [category ::sp/category]
+  (when-not (empty? category)
+    (-> category
+        lower-case
+        trim
+
+        ;; hyphenate white space
+        (clojure.string/replace #" +" "-")
+        keyword)))
+
+(defn-spec category-to-tag-list (s/or :singluar ::sp/tag, :composite ::sp/tag-list)
+  "given a `category` string, converts it into one or many tags."
+  [addon-host ::sp/catalogue-source, category ::sp/category]
+  (let [replacements (merge general-replacements (get replacement-map addon-host))
+        supplements (merge general-supplements (get supplement-map addon-host))
+
+        ;; if there is a replacement set of tags, we don't continue searching for supplementary tags
+        replacement-tags (get replacements category [])
+        supplementary-tags (get supplements category [])
+
+        tag-list (into replacement-tags supplementary-tags)]
+
+    (if-not (empty? replacement-tags)
+      ;; we found a set of replacement tags so we're done
+      tag-list
+
+      ;; couldn't find a replacement set of tags so parse the category
+      (let [bits (clojure.string/split category #"( & |, |: )+")]
+        (->> bits (map category-to-tag) (into tag-list) (remove nil?) vec)))))
+
+(defn-spec category-list-to-tag-list ::sp/tag-list
+  "given a list of category strings, converts them into a distinct list of tags by calling `category-to-tag-list`."
+  [addon-host ::sp/catalogue-source, category-list ::sp/category-list]
+  ;; sorting cuts down on noise in diffs.
+  ;; `set` because curseforge has duplicate categories
+  (->> category-list (map (partial category-to-tag-list addon-host)) flatten set sort vec))
+
+;;
+
+(st/instrument)

--- a/src/strongbox/tukui_api.clj
+++ b/src/strongbox/tukui_api.clj
@@ -54,13 +54,15 @@
   "process an item from a tukui catalogue into an addon-summary. slightly different values by game-track."
   [tukui-item map?, classic? boolean?]
   (let [ti tukui-item
+        category-list (if-let [cat (:category ti)] [cat] [])
         addon-summary
         {:source (if classic? "tukui-classic" "tukui")
          :source-id (-> ti :id Integer.)
 
          ;; single case of an addon with no category :(
          ;; 'SkullFlower UI', source-id 143
-         :category-list (if-let [cat (:category ti)] [cat] [])
+         :category-list category-list
+         :tag-list (utils/category-list-to-tag-list category-list)
          :download-count (-> ti :downloads Integer.)
          :game-track-list [(if classic? :classic :retail)]
          :label (:name ti)

--- a/src/strongbox/tukui_api.clj
+++ b/src/strongbox/tukui_api.clj
@@ -54,14 +54,15 @@
   "process an item from a tukui catalogue into an addon-summary. slightly different values by game-track."
   [tukui-item map?, classic? boolean?]
   (let [ti tukui-item
+        ;; single case of an addon with no category :(
+        ;; 'SkullFlower UI', source-id 143
         category-list (if-let [cat (:category ti)] [cat] [])
         addon-summary
         {:source (if classic? "tukui-classic" "tukui")
          :source-id (-> ti :id Integer.)
 
-         ;; single case of an addon with no category :(
-         ;; 'SkullFlower UI', source-id 143
-         :category-list category-list
+         ;; 2020-03: disabled in favour of :tag-list
+         ;;:category-list category-list
          :tag-list (utils/category-list-to-tag-list category-list)
          :download-count (-> ti :downloads Integer.)
          :game-track-list [(if classic? :classic :retail)]

--- a/src/strongbox/tukui_api.clj
+++ b/src/strongbox/tukui_api.clj
@@ -6,6 +6,7 @@
    [orchestra.core :refer [defn-spec]]
    ;;[taoensso.timbre :as log :refer [debug info warn error spy]]
    [strongbox
+    [tags :as tags]
     [http :as http]
     [utils :as utils]
     [specs :as sp]]))
@@ -63,7 +64,7 @@
 
          ;; 2020-03: disabled in favour of :tag-list
          ;;:category-list category-list
-         :tag-list (utils/category-list-to-tag-list category-list)
+         :tag-list (tags/category-list-to-tag-list "tukui" category-list)
          :download-count (-> ti :downloads Integer.)
          :game-track-list [(if classic? :classic :retail)]
          :label (:name ti)

--- a/src/strongbox/ui/gui.clj
+++ b/src/strongbox/ui/gui.clj
@@ -464,7 +464,7 @@
 (defn installed-addons-panel
   []
   (let [;; always visible when debugging and always available from the column menu
-        hidden-by-default-cols [:addon-id :group-id :primary? :update? :matched? :ignore? :categories :downloads :updated :source-id :track]
+        hidden-by-default-cols [:addon-id :group-id :primary? :update? :matched? :ignore? :tags :downloads :updated :source-id :track]
         tblmdl (sstbl/table-model :columns [{:key :name, :text "addon-id"}
                                             :group-id
                                             :primary?
@@ -481,7 +481,7 @@
                                             {:key :download-count, :text "downloads" :class Integer}
                                             {:key :updated-date, :text "updated"}
                                             {:key :interface-version, :text "WoW"}
-                                            {:key :category-list, :text "categories"}]
+                                            {:key :tag-list, :text "tags"}]
                                   :rows [])
 
         grid (x/table-x :id :tbl-installed-addons
@@ -572,7 +572,7 @@
                                             :source-id
                                             {:key :label :text "name"}
                                             :description
-                                            {:key :category-list :text "categories"}
+                                            {:key :tag-list :text "tags"}
                                             {:key :updated-date :text "updated"}
                                             {:key :download-count :text "downloads" :class Integer}]
                                   :rows [])

--- a/src/strongbox/utils.clj
+++ b/src/strongbox/utils.clj
@@ -385,46 +385,6 @@
       interface-version-to-game-version
       game-version-to-game-track))
 
-(defn-spec category-to-tag-list (s/or :singluar ::sp/tag, :composite ::sp/tag-list)
-  "given a `category` string, converts it into one or many tags."
-  [category ::sp/category]
-  (let [replacements {"Character Advancement" [:leveling :achievements]
-                      "Unit Frames" :unit-mods
-                      "Utility Mods" :utilities
-                      "Classic - General" :classic
-                      "Audio & Video" :audio-video
-                      "Battle Pets" [:pets :battle-bets]
-                      "ROFL" :misc
-                      "Other" :misc
-                      "Miscellaneous" :misc}
-        category (get replacements category category)
-
-        bits (when (string? category)
-               (clojure.string/split category #"( & |, |: )+"))]
-    (cond
-      ;; replacements
-      (not (string? category)) category
-
-      (empty? category) []
-
-      ;; category was split
-      (> (count bits) 1) (mapv category-to-tag-list bits)
-
-      :else (-> category
-                clojure.string/lower-case
-                clojure.string/trim
-
-                ;; hyphenate white space
-                (clojure.string/replace #" +" "-")
-                keyword))))
-
-(defn-spec category-list-to-tag-list ::sp/tag-list
-  "given a list of category strings, converts them into a distinct list of tags by calling `category-to-tag-list`."
-  [category-list ::sp/category-list]
-  ;; sorting cuts down on noise in diffs.
-  ;; `set` because curseforge has duplicate categories
-  (->> category-list (map category-to-tag-list) flatten set sort vec))
-
 ;; https://stackoverflow.com/questions/13789092/length-of-the-first-line-in-an-utf-8-file-with-bom
 (defn debomify
   [^String line]

--- a/src/strongbox/utils.clj
+++ b/src/strongbox/utils.clj
@@ -385,6 +385,42 @@
       interface-version-to-game-version
       game-version-to-game-track))
 
+(defn-spec category-to-tag-list (s/or :singluar ::sp/tag, :composite ::sp/tag-list)
+  [category ::sp/category]
+  (let [replacements {"Character Advancement" [:leveling :achievements]
+                      "Unit Frames" :unit-mods
+                      "Utility Mods" :utilities
+                      "Classic - General" :classic
+                      "Audio & Video" :audio-video
+                      "Battle Pets" [:pets :battle-bets]
+                      "ROFL" :misc
+                      "Other" :misc
+                      "Miscellaneous" :misc}
+        category (get replacements category category)
+
+        bits (when (string? category)
+               (clojure.string/split category #"( & |, |: )+"))]
+    (cond
+      ;; replacements
+      (not (string? category)) category
+
+      ;; category was split
+      (> (count bits) 1) (mapv category-to-tag-list bits)
+
+      :else (-> category
+                clojure.string/lower-case
+                clojure.string/trim
+
+                ;; hyphenate white space
+                (clojure.string/replace #" +" "-")
+                keyword))))
+
+(defn-spec category-list-to-tag-list ::sp/tag-list
+  [category-list ::sp/category-list]
+  ;; sorting cuts down on noise in diffs.
+  ;; `set` because curseforge has duplicate categories
+  (->> category-list (map category-to-tag-list) flatten set sort vec))
+
 ;; https://stackoverflow.com/questions/13789092/length-of-the-first-line-in-an-utf-8-file-with-bom
 (defn debomify
   [^String line]

--- a/src/strongbox/utils.clj
+++ b/src/strongbox/utils.clj
@@ -386,6 +386,7 @@
       game-version-to-game-track))
 
 (defn-spec category-to-tag-list (s/or :singluar ::sp/tag, :composite ::sp/tag-list)
+  "given a `category` string, converts it into one or many tags."
   [category ::sp/category]
   (let [replacements {"Character Advancement" [:leveling :achievements]
                       "Unit Frames" :unit-mods
@@ -404,6 +405,8 @@
       ;; replacements
       (not (string? category)) category
 
+      (empty? category) []
+
       ;; category was split
       (> (count bits) 1) (mapv category-to-tag-list bits)
 
@@ -416,6 +419,7 @@
                 keyword))))
 
 (defn-spec category-list-to-tag-list ::sp/tag-list
+  "given a list of category strings, converts them into a distinct list of tags by calling `category-to-tag-list`."
   [category-list ::sp/category-list]
   ;; sorting cuts down on noise in diffs.
   ;; `set` because curseforge has duplicate categories

--- a/src/strongbox/wowinterface.clj
+++ b/src/strongbox/wowinterface.clj
@@ -5,6 +5,7 @@
    [slugify.core :refer [slugify]]
    [orchestra.spec.test :as st]
    [strongbox
+    [tags :as tags]
     [utils :as utils :refer [to-url]]
     [http :as http]]
    [flatland.ordered.map :as omap]
@@ -166,7 +167,7 @@
                                category-list (reduce clojure.set/union (map :category-list group-list))]]
                      (merge addon
                             {;;:category-list category-list ;; 2020-03: disabled in favour of :tag-list
-                             :tag-list (utils/category-list-to-tag-list category-list)}))
+                             :tag-list (tags/category-list-to-tag-list "wowinterface" category-list)}))
 
         filelist (download-parse-filelist-file)
 

--- a/src/strongbox/wowinterface.clj
+++ b/src/strongbox/wowinterface.clj
@@ -165,7 +165,7 @@
                          :let [addon (first group-list)
                                category-list (reduce clojure.set/union (map :category-list group-list))]]
                      (merge addon
-                            {:category-list category-list
+                            {;;:category-list category-list ;; 2020-03: disabled in favour of :tag-list
                              :tag-list (utils/category-list-to-tag-list category-list)}))
 
         filelist (download-parse-filelist-file)

--- a/src/strongbox/wowinterface.clj
+++ b/src/strongbox/wowinterface.clj
@@ -162,9 +162,11 @@
         ;; group addons by their :source-id and then merge together, preserving the categories
         addon-groups (group-by :source-id addon-list)
         addon-list (for [[_ group-list] addon-groups
-                         :let [addon (first group-list)]]
-                     (assoc addon :category-list
-                            (reduce clojure.set/union (map :category-list group-list))))
+                         :let [addon (first group-list)
+                               category-list (reduce clojure.set/union (map :category-list group-list))]]
+                     (merge addon
+                            {:category-list category-list
+                             :tag-list (utils/category-list-to-tag-list category-list)}))
 
         filelist (download-parse-filelist-file)
 

--- a/test/fixtures/import-export--user-catalogue.json
+++ b/test/fixtures/import-export--user-catalogue.json
@@ -6,7 +6,7 @@
   "updated-datestamp" : "2019-11-21",
   "total" : 16,
   "addon-summary-list" : [ {
-    "category-list" : [ ],
+    "tag-list" : [ ],
     "download-count" : 62,
     "game-track-list" : [ "retail", "classic" ],
     "label" : "AdvancedInterfaceOptions",
@@ -16,7 +16,7 @@
     "updated-date" : "2019-09-24T22:50:31Z",
     "url" : "https://github.com/Stanzilla/AdvancedInterfaceOptions"
   }, {
-    "category-list" : [ ],
+    "tag-list" : [ ],
     "download-count" : 3,
     "game-track-list" : [ "retail" ],
     "label" : "AzeritePowerWeights",
@@ -26,7 +26,7 @@
     "updated-date" : "2019-11-03T15:46:40Z",
     "url" : "https://github.com/ahakola/AzeritePowerWeights"
   }, {
-    "category-list" : [ ],
+    "tag-list" : [ ],
     "download-count" : 9,
     "game-track-list" : [ "retail", "classic" ],
     "label" : "Chinchilla",
@@ -36,7 +36,7 @@
     "updated-date" : "2019-10-19T15:07:07Z",
     "url" : "https://github.com/Ravendwyr/Chinchilla"
   }, {
-    "category-list" : [ ],
+    "tag-list" : [ ],
     "download-count" : 95367,
     "game-track-list" : [ ],
     "label" : "ClassicCastbars",
@@ -46,7 +46,7 @@
     "updated-date" : "2019-11-19T21:00:54Z",
     "url" : "https://github.com/wardz/ClassicCastbars"
   }, {
-    "category-list" : [ ],
+    "tag-list" : [ ],
     "download-count" : 3448,
     "game-track-list" : [ ],
     "label" : "DBM-Classic",
@@ -56,7 +56,7 @@
     "updated-date" : "2019-11-19T15:40:24Z",
     "url" : "https://github.com/DeadlyBossMods/DBM-Classic"
   }, {
-    "category-list" : [ ],
+    "tag-list" : [ ],
     "download-count" : 9,
     "game-track-list" : [ "classic" ],
     "label" : "faction-friend",
@@ -66,7 +66,7 @@
     "updated-date" : "2019-10-16T00:42:45Z",
     "url" : "https://github.com/Dreamwalker-Collective/faction-friend"
   }, {
-    "category-list" : [ ],
+    "tag-list" : [ ],
     "download-count" : 3,
     "game-track-list" : [ "classic" ],
     "label" : "ipop-bar",
@@ -76,7 +76,7 @@
     "updated-date" : "2019-09-09T14:07:30Z",
     "url" : "https://github.com/sylvanaar/ipop-bar"
   }, {
-    "category-list" : [ ],
+    "tag-list" : [ ],
     "download-count" : 1,
     "game-track-list" : [ "classic" ],
     "label" : "LevelUpSpells",
@@ -86,7 +86,7 @@
     "updated-date" : "2019-10-21T09:27:08Z",
     "url" : "https://github.com/coolmodi/LevelUpSpells"
   }, {
-    "category-list" : [ ],
+    "tag-list" : [ ],
     "download-count" : 78082,
     "game-track-list" : [ "classic" ],
     "label" : "LunaUnitFrames",
@@ -96,7 +96,7 @@
     "updated-date" : "2019-10-31T14:53:01Z",
     "url" : "https://github.com/Aviana/LunaUnitFrames"
   }, {
-    "category-list" : [ ],
+    "tag-list" : [ ],
     "download-count" : 56,
     "game-track-list" : [ "retail", "classic" ],
     "label" : "prat-3-0",
@@ -106,7 +106,7 @@
     "updated-date" : "2019-09-13T17:30:38Z",
     "url" : "https://github.com/sylvanaar/prat-3-0"
   }, {
-    "category-list" : [ ],
+    "tag-list" : [ ],
     "download-count" : 110,
     "game-track-list" : [ ],
     "label" : "RaidBrowser",
@@ -116,7 +116,7 @@
     "updated-date" : "2018-08-01T18:16:23Z",
     "url" : "https://github.com/Ostoic/RaidBrowser"
   }, {
-    "category-list" : [ ],
+    "tag-list" : [ ],
     "download-count" : 269,
     "game-track-list" : [ ],
     "label" : "RealUI",
@@ -126,7 +126,7 @@
     "updated-date" : "2019-10-04T21:57:00Z",
     "url" : "https://github.com/RealUI/RealUI"
   }, {
-    "category-list" : [ ],
+    "tag-list" : [ ],
     "download-count" : 17726,
     "game-track-list" : [ "classic" ],
     "label" : "RingMenu",
@@ -136,7 +136,7 @@
     "updated-date" : "2019-10-06T12:18:47Z",
     "url" : "https://github.com/jsb/RingMenu"
   }, {
-    "category-list" : [ ],
+    "tag-list" : [ ],
     "download-count" : 133,
     "game-track-list" : [ "retail" ],
     "label" : "TellMeWhen",
@@ -146,7 +146,7 @@
     "updated-date" : "2019-09-30T04:18:47Z",
     "url" : "https://github.com/ascott18/TellMeWhen"
   }, {
-    "category-list" : [ ],
+    "tag-list" : [ ],
     "download-count" : 5,
     "game-track-list" : [ "retail", "classic" ],
     "label" : "who-lib",
@@ -156,7 +156,7 @@
     "updated-date" : "2019-08-27T23:23:36Z",
     "url" : "https://github.com/sylvanaar/who-lib"
   }, {
-    "category-list" : [ ],
+    "tag-list" : [ ],
     "download-count" : 19,
     "game-track-list" : [ "retail", "classic" ],
     "label" : "wow-instant-messenger",

--- a/test/strongbox/catalogue_test.clj
+++ b/test/strongbox/catalogue_test.clj
@@ -40,7 +40,7 @@
                 :label "HealComm"
                 :name "healcomm"
                 :download-count 30946
-                :category-list []}
+                :tag-list []}
 
         addon2 {:url "https://github.com/Ravendwyr/Chinchilla"
                 :updated-date "2019-10-09T17:40:04Z"
@@ -49,7 +49,7 @@
                 :label "Chinchilla"
                 :name "chinchilla"
                 :download-count 30946
-                :category-list []}
+                :tag-list []}
 
         cat-a (catalogue/new-catalogue [addon1])
         cat-b (catalogue/new-catalogue [addon2])
@@ -73,7 +73,7 @@
                 :label "HealComm"
                 :name "healcomm"
                 :download-count 30946
-                :category-list []}
+                :tag-list []}
 
         addon2 {:url "https://github.com/Aviana/HealComm"
                 :updated-date "2019-10-09T17:40:04Z" ;; <=
@@ -82,7 +82,7 @@
                 :label "HealComm"
                 :name "healcomm"
                 :download-count 30946
-                :category-list []}
+                :tag-list []}
 
         cat-a (catalogue/new-catalogue [addon1])
         cat-b (catalogue/new-catalogue [addon2])
@@ -109,7 +109,7 @@
                         :name "healcomm"
                         :download-count 30946
                         :game-track-list []
-                        :category-list []}
+                        :tag-list []}
 
             cases [["https://github.com/Aviana/HealComm" github-api]]]
         (doseq [[given expected] cases]

--- a/test/strongbox/catalogue_test.clj
+++ b/test/strongbox/catalogue_test.clj
@@ -32,17 +32,6 @@
                     :addon-summary-list addon-list}]
       (is (= (catalogue/format-catalogue-data addon-list created updated) expected)))))
 
-(deftest merge-curse-wowi-catalogues
-  (testing "dates are correct after a merge"
-    (let [aa {:datestamp "2001-01-01" :updated-datestamp "2001-01-02" :spec {:version 1} :addon-summary-list [] :total 0}
-          ab {:datestamp "2001-01-03" :updated-datestamp "2001-01-04" :spec {:version 1} :addon-summary-list [] :total 0}
-          expected {:spec {:version 1}
-                    :datestamp "2001-01-01"
-                    :updated-datestamp "2001-01-04"
-                    :total 0
-                    :addon-summary-list []}]
-      (is (= (catalogue/-merge-curse-wowi-catalogues aa ab) expected)))))
-
 (deftest merge-catalogues
   (let [addon1 {:url "https://github.com/Aviana/HealComm"
                 :updated-date "2019-10-09T17:40:04Z"

--- a/test/strongbox/core_test.clj
+++ b/test/strongbox/core_test.clj
@@ -267,7 +267,7 @@
                            :matched? true}
 
                           {:description "Does what every addon does, just better",
-                           :tag-list [:map :minimap :professions]
+                           :tag-list [:coords :map :minimap :professions :ui]
                            :update? false,
                            :updated-date "2019-07-03T07:11:47Z",
                            :group-id "https://www.curseforge.com/wow/addons/everyotheraddon",
@@ -351,7 +351,7 @@
                            :matched? true}
 
                           {:description "Does what every addon does, just better",
-                           :tag-list [:map :minimap :professions]
+                           :tag-list [:coords :map :minimap :professions :ui]
                            :update? false,
                            :updated-date "2019-07-03T07:11:47Z",
                            :group-id "https://www.curseforge.com/wow/addons/everyotheraddon",

--- a/test/strongbox/core_test.clj
+++ b/test/strongbox/core_test.clj
@@ -217,10 +217,12 @@
           every-other-addon-api (slurp (fixture-path "curseforge-api-addon--everyotheraddon.json"))
 
           addon-summary-list (utils/load-json-file (fixture-path "import-export--dummy-catalogue.json"))
+          dummy-catalogue (assoc (catalogue/new-catalogue [])
+                                 :addon-summary-list addon-summary-list)
 
           fake-routes {;; catalogue
                        "https://raw.githubusercontent.com/ogri-la/wowman-data/master/short-catalog.json"
-                       {:get (fn [req] {:status 200 :body (utils/to-json (catalogue/new-catalogue addon-summary-list))})}
+                       {:get (fn [req] {:status 200 :body (utils/to-json dummy-catalogue)})}
 
                        ;; every-addon
                        "https://addons-ecs.forgesvc.net/api/v2/addon/1"
@@ -245,7 +247,7 @@
                 output-path (fixture-path "import-export--export-v1.json")
 
                 expected [{:description "Does what no other addon does, slightly differently",
-                           :category-list ["Bags & Inventory"],
+                           :tag-list [:bags :inventory]
                            :update? false,
                            :updated-date "2019-06-26T01:21:39Z",
                            :group-id "https://www.curseforge.com/wow/addons/everyaddon",
@@ -265,7 +267,7 @@
                            :matched? true}
 
                           {:description "Does what every addon does, just better",
-                           :category-list ["Professions" "Map & Minimap"],
+                           :tag-list [:map :minimap :professions]
                            :update? false,
                            :updated-date "2019-07-03T07:11:47Z",
                            :group-id "https://www.curseforge.com/wow/addons/everyotheraddon",
@@ -299,9 +301,12 @@
 
           addon-summary-list (utils/load-json-file (fixture-path "import-export--dummy-catalogue.json"))
 
+          dummy-catalogue (assoc (catalogue/new-catalogue [])
+                                 :addon-summary-list addon-summary-list)
+
           fake-routes {;; catalogue
                        "https://raw.githubusercontent.com/ogri-la/wowman-data/master/short-catalog.json"
-                       {:get (fn [req] {:status 200 :body (utils/to-json (catalogue/new-catalogue addon-summary-list))})}
+                       {:get (fn [req] {:status 200 :body (utils/to-json dummy-catalogue)})}
 
                        ;; every-addon
                        "https://addons-ecs.forgesvc.net/api/v2/addon/1"
@@ -326,7 +331,7 @@
                 output-path (fixture-path "import-export--export-v2.json")
 
                 expected [{:description "Does what no other addon does, slightly differently",
-                           :category-list ["Bags & Inventory"],
+                           :tag-list [:bags :inventory]
                            :update? false,
                            :updated-date "2019-06-26T01:21:39Z",
                            :group-id "https://www.curseforge.com/wow/addons/everyaddon",
@@ -346,7 +351,7 @@
                            :matched? true}
 
                           {:description "Does what every addon does, just better",
-                           :category-list ["Professions" "Map & Minimap"],
+                           :tag-list [:map :minimap :professions]
                            :update? false,
                            :updated-date "2019-07-03T07:11:47Z",
                            :group-id "https://www.curseforge.com/wow/addons/everyotheraddon",
@@ -399,9 +404,12 @@
                                      :exposeAsAlternative nil}]}
           alt-api-result (assoc-in api-result [:latestFiles 0 :displayName] "v8.20.00")
 
+          dummy-catalogue (assoc (catalogue/new-catalogue [])
+                                 :addon-summary-list [catalogue])
+
           fake-routes {;; catalogue
                        "https://raw.githubusercontent.com/ogri-la/wowman-data/master/short-catalog.json"
-                       {:get (fn [req] {:status 200 :body (utils/to-json (catalogue/new-catalogue [catalogue]))})}
+                       {:get (fn [req] {:status 200 :body (utils/to-json dummy-catalogue)})}
 
                        ;; every-addon
                        "https://addons-ecs.forgesvc.net/api/v2/addon/0"
@@ -456,17 +464,18 @@
 
 ;; todo: install classic addon into retail game track
 
-(deftest db-row-wrangling
+(deftest db-split-tag-list
   (testing "converting a tab separated list back into an actual list works as expected"
     (let [cases [[nil []]
                  ["" []]
                  ["|" []]
-                 ["foo" ["foo"]]
-                 ["bar|baz" ["bar" "baz"]]]]
+                 ["foo" [:foo]]
+                 ["bar|baz" [:bar :baz]]]]
 
       (doseq [[given expected] cases]
-        (is (= expected (core/db-split-category-list given))))))
+        (is (= expected (core/db-split-tag-list given)))))))
 
+(deftest db-gen-game-track-list
   (testing "game track fields are turned back into a list"
     (let [cases [[{} {}]
                  [{:retail-track true} {:game-track-list [:retail]}]
@@ -499,7 +508,8 @@
 
           expected (subs (:description addon-with-long-description) 0 255)
 
-          dummy-catalogue (catalogue/new-catalogue [addon-with-long-description])
+          dummy-catalogue (assoc (catalogue/new-catalogue [])
+                                 :addon-summary-list [addon-with-long-description])
           fake-routes {"https://raw.githubusercontent.com/ogri-la/wowman-data/master/short-catalog.json"
                        {:get (fn [req] {:status 200 :body (utils/to-json dummy-catalogue)})}}]
 
@@ -526,7 +536,7 @@
   {:label "EveryAddon",
    :name  "everyaddon",
    :description  "Does what no other addon does, slightly differently"
-   :category-list  ["Auction & Economy", "Data Broker"],
+   :tag-list [:auction :data-broker :economy]
    :source "curseforge"
    :source-id 1
    :created-date  "2009-02-08T13:30:30Z",
@@ -797,7 +807,7 @@
                       :label "HealComm"
                       :name "healcomm"
                       :download-count 30946
-                      :category-list []}
+                      :tag-list []}
 
           expected (merge (catalogue/new-catalogue [])
                           {;; hack, catalogue/format-catalogue-data orders the addon summary make them uncomparable
@@ -816,7 +826,7 @@
                       :label "HealComm"
                       :name "healcomm"
                       :download-count 30946
-                      :category-list []}
+                      :tag-list []}
 
           expected (merge (catalogue/new-catalogue [])
                           {;; hack, catalogue/format-catalogue-data orders the addon summary make them uncomparable
@@ -849,7 +859,7 @@
 
           expected-addon-dir (utils/join install-dir "EveryAddon")
 
-          expected-user-catalogue [{:category-list [],
+          expected-user-catalogue [{:tag-list [],
                                     :game-track-list [],
                                     :updated-date "2019-10-09T17:40:04Z",
                                     :name "healcomm",
@@ -881,7 +891,7 @@
 
           addon-summary {:name "everyaddon"
                          :label "EveryAddon"
-                         :category-list []
+                         :tag-list []
                          :updated-date "2001-01-01"
                          :download-count 123
                          :source "wowinterface"
@@ -900,7 +910,7 @@
                     :interface-version 70000
                     :installed-version "1.2.3"
 
-                    :category-list []
+                    :tag-list []
                     :updated-date "2001-01-01"
                     :download-count 123
                     :source "wowinterface"

--- a/test/strongbox/curseforge_api_test.clj
+++ b/test/strongbox/curseforge_api_test.clj
@@ -165,6 +165,7 @@
           expected [{:created-date "2016-05-09T17:21:30.1Z",
                      :description "Restores access to removed interface options in Legion",
                      :category-list ["Miscellaneous"],
+                     :tag-list [:misc],
                      :updated-date "2019-08-30T14:39:44.943Z",
                      :name "advancedinterfaceoptions",
                      :label "AdvancedInterfaceOptions",

--- a/test/strongbox/curseforge_api_test.clj
+++ b/test/strongbox/curseforge_api_test.clj
@@ -16,7 +16,7 @@
           ;; what would be seen in the catalogue
           addon-summary {:created-date "2010-05-07T18:48:16Z",
                          :description "Does what no other addon does, slightly differently",
-                         :category-list ["Bags & Inventory"],
+                         :tag-list [:bags :inventory]
                          :updated-date "2019-06-26T01:21:39Z",
                          :age "new",
                          :name "everyaddon",
@@ -41,7 +41,7 @@
                        {:get (fn [req] {:status 200 :body api-results})}}
           addon-summary {:created-date "2010-05-07T18:48:16Z",
                          :description "Does what no other addon does, slightly differently",
-                         :category-list ["Bags & Inventory"],
+                         :tag-list [:bags :inventory]
                          :updated-date "2019-06-26T01:21:39Z",
                          :age "new",
                          :name "everyaddon",
@@ -164,7 +164,6 @@
                        {:get (fn [req] {:status 200 :body fixture})}}
           expected [{:created-date "2016-05-09T17:21:30.1Z",
                      :description "Restores access to removed interface options in Legion",
-                     :category-list ["Miscellaneous"],
                      :tag-list [:misc],
                      :updated-date "2019-08-30T14:39:44.943Z",
                      :name "advancedinterfaceoptions",

--- a/test/strongbox/github_api_test.clj
+++ b/test/strongbox/github_api_test.clj
@@ -29,7 +29,7 @@
                     :name "healcomm"
                     :download-count 30946
                     :game-track-list []
-                    :category-list []}
+                    :tag-list []}
 
           ;; all of these should yield the above
           cases ["https://github.com/Aviana/HealComm" ;; perfect case
@@ -94,7 +94,7 @@
                  :label "HealComm"
                  :name "healcomm"
                  :download-count 30946
-                 :category-list []}
+                 :tag-list []}
 
           game-track :retail
 
@@ -105,7 +105,7 @@
                     :label "HealComm"
                     :name "healcomm"
                     :download-count 30946
-                    :category-list []
+                    :tag-list []
 
                     :download-url "https://github.com/Aviana/HealComm/releases/download/2.04/HealComm.zip"
                     :version "2.04 Beta"}
@@ -125,11 +125,11 @@
                  :label "Chinchilla"
                  :name "chinchilla"
                  :download-count 30946
-                 :category-list []}
+                 :tag-list []}
 
           game-track :classic
 
-          expected {:category-list []
+          expected {:tag-list []
                     :updated-date "2019-10-09T17:40:04Z"
                     :name "chinchilla"
                     :source "github"
@@ -156,7 +156,7 @@
                  :label "Necrosis-classic"
                  :name "necrosis-classic"
                  :download-count 30946
-                 :category-list []}
+                 :tag-list []}
 
           expected nil
 
@@ -176,7 +176,7 @@
                  :label "RingMenu"
                  :name "ringmenu"
                  :download-count 30946
-                 :category-list []}
+                 :tag-list []}
 
           game-track :retail
 
@@ -216,7 +216,7 @@
            :name "healcomm"
            :download-count 30946
            :game-track-list [] ;; 'no game tracks'
-           :category-list []}
+           :tag-list []}
 
           latest-release {:name "Release 1.2.3"
                           :assets [{:content_type "application/zip"
@@ -261,7 +261,7 @@
            :name "healcomm"
            :download-count 30946
            :game-track-list [] ;; 'no game tracks'
-           :category-list []}
+           :tag-list []}
 
           latest-release {:name "Release 1.2.3"
                           :assets [{:content_type "application/zip"
@@ -335,7 +335,7 @@
            :name "healcomm"
            :download-count 30946
            :game-track-list [] ;; 'no game tracks'
-           :category-list []}
+           :tag-list []}
 
           game-track :retail
 

--- a/test/strongbox/http_test.clj
+++ b/test/strongbox/http_test.clj
@@ -12,7 +12,7 @@
           zombie-addon {:name "Brewmaster Tools"
                         :url "https://www.curseforge.com/wow/addons/brewmastertools"
                         :label ""
-                        :category-list []
+                        :tag-list []
                         :updated-date "2019-01-01T00:00:00Z" :download-count 0}
           fake-routes {"https://www.curseforge.com/wow/addons/brewmastertools/files"
                        {:get (fn [req] {:status 404 :reason-phrase "Not Found" :body "<h1>Not Found</h1>"})}}]

--- a/test/strongbox/tags_test.clj
+++ b/test/strongbox/tags_test.clj
@@ -1,0 +1,62 @@
+(ns strongbox.tags-test
+  (:require
+   [clojure.test :refer [deftest testing is use-fixtures]]
+   [strongbox.tags :as tags]))
+
+(deftest category-to-tag
+  (testing "a token from a standard category string is converted into a 'tag'"
+    (let [cases [["" nil]
+                 ["foo" :foo]
+                 ["foo bar" :foo-bar]
+
+                 ;; doesn't handle tokenisation, see `category-to-tag-list`
+                 ["foo & bar" :foo-&-bar]
+                 ;; see? total mess
+                 ["foo, bar" (keyword "foo,-bar")]]]
+      (doseq [[given expected] cases]
+        (is (= expected (tags/category-to-tag given)))))))
+
+(deftest category-to-tag-list
+  (testing "standard category is parsed in to a list of tags."
+    (let [cases [["" []]
+                 ["foo" [:foo]]
+                 ["foo bar" [:foo-bar]]
+                 ["foo & bar" [:foo :bar]]
+                 ["foo, bar" [:foo :bar]]
+                 ["foo: bar" [:foo :bar]]]]
+      (doseq [[given expected] cases]
+        (is (= expected (tags/category-to-tag-list "addon-host" given)))))))
+
+(deftest category-to-tag-list-replacement
+  (testing "specific categories get a better replacement"
+    (let [cases [;; we won't bother with a 'spell' tag for wowinterface
+                 ["wowinterface" "Buff, Debuff, Spell" [:buffs :debuffs]]
+
+                 ;; curseforge doesn't bother with it either but if we say it came from
+                 ;; curseforge then we have no specific replacement rules for it
+                 ["curseforge" "Buff, Debuff, Spell" [:buff :debuff :spell]]
+
+                 ["wowinterface" "Classic - General" [:classic]]
+                 ["curseforge" "Damage Dealer" [:dps]]
+                 ["tukui" "Edited UIs & Compilations" [:ui :compilations]]]]
+      (doseq [[addon-host given expected] cases]
+        (is (= expected (tags/category-to-tag-list addon-host given)))))))
+
+(deftest category-to-tag-list-supplement
+  (testing "specific categories get parsed like usual, but we tack on extra tags as well"
+    (let [cases [;; the simple 'pets' category gets supplemented with tags present for other hosts
+                 ["wowinterface" "Pets" [:battle-pets :companions :pets]]
+                 ["curseforge" "Arena" [:pvp :arena]]
+                 ;; composite categories are parsed into individual tags as well
+                 ["tukui" "Map & Minimap" [:coords :ui :map :minimap]]]]
+      (doseq [[addon-host given expected] cases]
+        (is (= expected (tags/category-to-tag-list addon-host given)))))))
+
+(deftest category-list-to-tag-list
+  (testing "list of categories are parsed, sorted, filtered and de-duplicated correctly"
+    (let [cases [[[""] []]
+                 [["" "" ""] []]
+                 [["foo" "foo bar" "bar & baz" "bup, bap"] [:bap :bar :baz :bup :foo :foo-bar]]
+                 [["Miscellaneous" "Miscellaneous"] [:misc]]]]
+      (doseq [[given expected] cases]
+        (is (= expected (tags/category-list-to-tag-list "addon-host" given)))))))

--- a/test/strongbox/tags_test.clj
+++ b/test/strongbox/tags_test.clj
@@ -22,10 +22,16 @@
                  ["foo" [:foo]]
                  ["foo bar" [:foo-bar]]
                  ["foo & bar" [:foo :bar]]
+                 ["foo & bar & baz" [:foo :bar :baz]]
                  ["foo, bar" [:foo :bar]]
-                 ["foo: bar" [:foo :bar]]]]
+                 ["foo, bar, baz" [:foo :bar :baz]]
+                 ["foo: bar" [:foo :bar]]
+                 ["foo: bar: baz", [:foo :bar :baz]]
+
+                 ;; nothing does this, but it's supported :)
+                 ["foo & bar: baz, bup" [:foo :bar :baz :bup]]]]
       (doseq [[given expected] cases]
-        (is (= expected (tags/category-to-tag-list "addon-host" given)))))))
+        (is (= expected (tags/category-to-tag-list "unhandled-addon-host" given)))))))
 
 (deftest category-to-tag-list-replacement
   (testing "specific categories get a better replacement"
@@ -40,7 +46,10 @@
                  ["curseforge" "Damage Dealer" [:dps]]
                  ["tukui" "Edited UIs & Compilations" [:ui :compilations]]]]
       (doseq [[addon-host given expected] cases]
-        (is (= expected (tags/category-to-tag-list addon-host given)))))))
+        (is (= expected (tags/category-to-tag-list addon-host given))))))
+
+  (testing "specific categories get a better replacement no matter which host they come from"
+    (is (= [:misc] (tags/category-to-tag-list "unhandled-addon-host" "Miscellaneous")))))
 
 (deftest category-to-tag-list-supplement
   (testing "specific categories get parsed like usual, but we tack on extra tags as well"
@@ -50,7 +59,10 @@
                  ;; composite categories are parsed into individual tags as well
                  ["tukui" "Map & Minimap" [:coords :ui :map :minimap]]]]
       (doseq [[addon-host given expected] cases]
-        (is (= expected (tags/category-to-tag-list addon-host given)))))))
+        (is (= expected (tags/category-to-tag-list addon-host given))))))
+
+  (testing "specific categories get extra tags no matter which host they come from"
+    (is (= [:class :caster :priest] (tags/category-to-tag-list "unhandled-addon-host" "Priest")))))
 
 (deftest category-list-to-tag-list
   (testing "list of categories are parsed, sorted, filtered and de-duplicated correctly"
@@ -59,4 +71,4 @@
                  [["foo" "foo bar" "bar & baz" "bup, bap"] [:bap :bar :baz :bup :foo :foo-bar]]
                  [["Miscellaneous" "Miscellaneous"] [:misc]]]]
       (doseq [[given expected] cases]
-        (is (= expected (tags/category-list-to-tag-list "addon-host" given)))))))
+        (is (= expected (tags/category-list-to-tag-list "unhandled-addon-host" given)))))))

--- a/test/strongbox/tukui_api_test.clj
+++ b/test/strongbox/tukui_api_test.clj
@@ -100,7 +100,7 @@
                        {:get (fn [req] {:status 200 :body fixture})}}
 
           addon-summary {:description "A user interface designed around user-friendliness with extra features that are not included in the standard ui",
-                         :tag-list [:full-ui-replacements]
+                         :tag-list [:ui]
                          :game-track-list [:classic :retail],
                          :updated-date "2019-12-05T00:00:00Z",
                          :name "elvui",

--- a/test/strongbox/tukui_api_test.clj
+++ b/test/strongbox/tukui_api_test.clj
@@ -15,7 +15,6 @@
                        {:get (fn [req] {:status 200 :body fixture})}}
 
           expected [{:description "Add roleplaying fields to ElvUI to create RP UIs.",
-                     :category-list ["Roleplay"],
                      :tag-list [:roleplay]
                      :game-track-list [:retail],
                      :updated-date "2019-07-29T20:48:25Z",
@@ -34,7 +33,6 @@
                        {:get (fn [req] {:status 200 :body fixture})}}
 
           expected [{:description "BenikUI is an external ElvUI Classic mod, adding different frame style and new features like detatched portraits and dashboards.",
-                     :category-list ["Plugins: ElvUI"],
                      :tag-list [:elvui :plugins]
                      :game-track-list [:classic],
                      :updated-date "2019-10-27T23:32:28Z",
@@ -53,7 +51,6 @@
                        {:get (fn [req] {:status 200 :body fixture})}}
 
           expected {:description "A user interface designed around user-friendliness with extra features that are not included in the standard ui",
-                    :category-list ["Full UI Replacements"],
                     :tag-list [:full-ui-replacements]
                     :game-track-list [:classic :retail],
                     :updated-date "2019-12-05T00:00:00Z",
@@ -76,7 +73,7 @@
                        {:get (fn [req] {:status 200 :body fixture})}}
 
           addon-summary {:description "Add roleplaying fields to ElvUI to create RP UIs.",
-                         :category-list ["Roleplay"],
+                         :tag-list [:roleplay],
                          :game-track-list [:retail],
                          :updated-date "2019-07-29T20:48:25Z",
                          :name "-rp-tags",
@@ -103,7 +100,7 @@
                        {:get (fn [req] {:status 200 :body fixture})}}
 
           addon-summary {:description "A user interface designed around user-friendliness with extra features that are not included in the standard ui",
-                         :category-list ["Full UI Replacements"],
+                         :tag-list [:full-ui-replacements]
                          :game-track-list [:classic :retail],
                          :updated-date "2019-12-05T00:00:00Z",
                          :name "elvui",

--- a/test/strongbox/tukui_api_test.clj
+++ b/test/strongbox/tukui_api_test.clj
@@ -51,7 +51,7 @@
                        {:get (fn [req] {:status 200 :body fixture})}}
 
           expected {:description "A user interface designed around user-friendliness with extra features that are not included in the standard ui",
-                    :tag-list [:full-ui-replacements]
+                    :tag-list [:ui]
                     :game-track-list [:classic :retail],
                     :updated-date "2019-12-05T00:00:00Z",
                     :name "elvui",

--- a/test/strongbox/tukui_api_test.clj
+++ b/test/strongbox/tukui_api_test.clj
@@ -16,6 +16,7 @@
 
           expected [{:description "Add roleplaying fields to ElvUI to create RP UIs.",
                      :category-list ["Roleplay"],
+                     :tag-list [:roleplay]
                      :game-track-list [:retail],
                      :updated-date "2019-07-29T20:48:25Z",
                      :name "-rp-tags",
@@ -34,6 +35,7 @@
 
           expected [{:description "BenikUI is an external ElvUI Classic mod, adding different frame style and new features like detatched portraits and dashboards.",
                      :category-list ["Plugins: ElvUI"],
+                     :tag-list [:elvui :plugins]
                      :game-track-list [:classic],
                      :updated-date "2019-10-27T23:32:28Z",
                      :name "benikui-classic",
@@ -52,6 +54,7 @@
 
           expected {:description "A user interface designed around user-friendliness with extra features that are not included in the standard ui",
                     :category-list ["Full UI Replacements"],
+                    :tag-list [:full-ui-replacements]
                     :game-track-list [:classic :retail],
                     :updated-date "2019-12-05T00:00:00Z",
                     :name "elvui",

--- a/test/strongbox/utils_test.clj
+++ b/test/strongbox/utils_test.clj
@@ -228,3 +228,26 @@
                [["foo" -100] ""]]]
     (doseq [[[string max] expected] cases]
       (is (= expected (utils/safe-subs string max))))))
+
+(deftest category-to-tag-list
+  (let [cases [["" []]
+               ["foo" :foo]
+               ["foo bar" :foo-bar]
+               ["foo & bar" [:foo :bar]]
+               ["foo, bar" [:foo :bar]]
+               ["foo: bar" [:foo :bar]]]]
+
+    (doseq [[given expected] cases]
+      (is (= expected (utils/category-to-tag-list given))))))
+
+(deftest category-list-to-tag-list
+  (let [cases [[[""] []]
+               [["" "" ""] []]
+
+               [["foo" "foo bar" "bar & baz" "bup, bap"] [:bap :bar :baz :bup :foo :foo-bar]]
+
+               [["Miscellaneous" "Miscellaneous"] [:misc]]]]
+
+    (doseq [[given expected] cases]
+      (is (= expected (utils/category-list-to-tag-list given))))))
+

--- a/test/strongbox/utils_test.clj
+++ b/test/strongbox/utils_test.clj
@@ -228,26 +228,3 @@
                [["foo" -100] ""]]]
     (doseq [[[string max] expected] cases]
       (is (= expected (utils/safe-subs string max))))))
-
-(deftest category-to-tag-list
-  (let [cases [["" []]
-               ["foo" :foo]
-               ["foo bar" :foo-bar]
-               ["foo & bar" [:foo :bar]]
-               ["foo, bar" [:foo :bar]]
-               ["foo: bar" [:foo :bar]]]]
-
-    (doseq [[given expected] cases]
-      (is (= expected (utils/category-to-tag-list given))))))
-
-(deftest category-list-to-tag-list
-  (let [cases [[[""] []]
-               [["" "" ""] []]
-
-               [["foo" "foo bar" "bar & baz" "bup, bap"] [:bap :bar :baz :bup :foo :foo-bar]]
-
-               [["Miscellaneous" "Miscellaneous"] [:misc]]]]
-
-    (doseq [[given expected] cases]
-      (is (= expected (utils/category-list-to-tag-list given))))))
-

--- a/test/strongbox/wowinterface_api_test.clj
+++ b/test/strongbox/wowinterface_api_test.clj
@@ -15,7 +15,7 @@
                  :label "Rotation Master",
                  :updated-date "2019-07-29T21:37:00Z",
                  :download-count 80,
-                 :category-list #{"dummy"}
+                 :tag-list [:dummy]
                  :source "wowinterface"
                  :source-id 25079
                  :game-track-list [:retail]}
@@ -27,7 +27,7 @@
                     :label "Rotation Master"
                     :updated-date "2019-07-29T21:37:00Z"
                     :download-count 80
-                    :category-list #{"dummy"}
+                    :tag-list [:dummy]
                     :source "wowinterface"
                     :source-id 25079
                     :game-track-list [game-track]


### PR DESCRIPTION
* removes the logic that merged the curse and wowi catalogues
* adds a `tag-list` alongside `category-list` 

- [x] do a proper tag normalisation, mapping categories between hosts to a single set of common tags
- [x] review