### PR TITLE
User config fixture fix

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -81,17 +81,15 @@ see CHANGELOG.md for a more formal list of changes by release
 * remember selected addon dir
     - done
 
-### todo
-
-* catalogue updates
-
-    - publish a 'strongbox-catalogue' repo
-        - just like wowman-data, but for strongbox
-
-
 * bug, test fixtures for user-config had their :catalog value renamed to :catalogue
         - revert those changes
         - add a step in the parsing that renames those values to 'catalogue'
+
+### todo
+
+* catalogue updates
+    - publish a 'strongbox-catalogue' repo
+        - just like wowman-data, but for strongbox
 
 * spec clean up
     * it's never been particularly clear in my head what some of those specs are

--- a/test/fixtures/user-config-0.10.json
+++ b/test/fixtures/user-config-0.10.json
@@ -1,5 +1,5 @@
 {
-  "selected-catalogue" : "full",
+  "selected-catalog" : "full",
   "debug?" : true,
   "addon-dir-list" : [ {
     "addon-dir" : "/tmp/.strongbox-bar",

--- a/test/fixtures/user-config-0.11.json
+++ b/test/fixtures/user-config-0.11.json
@@ -1,5 +1,5 @@
 {
-  "selected-catalogue" : "full",
+  "selected-catalog" : "full",
   "debug?" : true,
   "gui-theme" : "dark",
   "addon-dir-list" : [ {

--- a/test/fixtures/user-config-0.12.json
+++ b/test/fixtures/user-config-0.12.json
@@ -1,5 +1,5 @@
 {
-  "selected-catalogue" : "full",
+  "selected-catalog" : "full",
   "gui-theme" : "dark",
   "addon-dir-list" : [ {
     "addon-dir" : "/tmp/.strongbox-bar",

--- a/test/strongbox/config_test.clj
+++ b/test/strongbox/config_test.clj
@@ -160,7 +160,7 @@
                     :selected-addon-dir nil}]
       (is (= expected (config/handle-selected-addon-dir given))))))
 
-(deftest load-settings
+(deftest load-settings-0.9
   (testing "a standard config file circa 0.9 is loaded and parsed as expected"
     (let [cli-opts {}
           cfg-file (fixture-path "user-config-0.9.json")
@@ -185,8 +185,9 @@
                                                  {:addon-dir "/tmp/.strongbox-foo", :game-track :classic}]}
                     :etag-db {}}]
 
-      (is (= expected (config/load-settings cli-opts cfg-file etag-db-file)))))
+      (is (= expected (config/load-settings cli-opts cfg-file etag-db-file))))))
 
+(deftest load-settings-0.10
   (testing "a standard config file circa 0.10 is loaded and parsed as expected"
     (let [cli-opts {}
           cfg-file (fixture-path "user-config-0.10.json")
@@ -211,8 +212,9 @@
                                                  {:addon-dir "/tmp/.strongbox-foo", :game-track :classic}]}
                     :etag-db {}}]
 
-      (is (= expected (config/load-settings cli-opts cfg-file etag-db-file)))))
+      (is (= expected (config/load-settings cli-opts cfg-file etag-db-file))))))
 
+(deftest load-settings-0.11
   (testing "a standard config file circa 0.11 is loaded and parsed as expected"
     (let [cli-opts {}
           cfg-file (fixture-path "user-config-0.11.json")
@@ -237,8 +239,9 @@
                                 :addon-dir-list [{:addon-dir "/tmp/.strongbox-bar", :game-track :retail}
                                                  {:addon-dir "/tmp/.strongbox-foo", :game-track :classic}]}
                     :etag-db {}}]
-      (is (= expected (config/load-settings cli-opts cfg-file etag-db-file)))))
+      (is (= expected (config/load-settings cli-opts cfg-file etag-db-file))))))
 
+(deftest load-settings-0.12
   (testing "a standard config file circa 0.12 is loaded and parsed as expected"
     (let [cli-opts {}
           cfg-file (fixture-path "user-config-0.12.json")
@@ -262,8 +265,9 @@
                                 :addon-dir-list [{:addon-dir "/tmp/.strongbox-bar", :game-track :retail}
                                                  {:addon-dir "/tmp/.strongbox-foo", :game-track :classic}]}
                     :etag-db {}}]
-      (is (= expected (config/load-settings cli-opts cfg-file etag-db-file)))))
+      (is (= expected (config/load-settings cli-opts cfg-file etag-db-file))))))
 
+(deftest load-settings-1.0
   (testing "a standard config file circa 1.0 is loaded and parsed as expected"
     (let [cli-opts {}
           cfg-file (fixture-path "user-config-1.0.json")


### PR DESCRIPTION
a bug was found in a set of user configuration test fixtures that was introduced during the bulk renaming of 'catalog' to 'catalogue'.