### PR TITLE
timings

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -111,6 +111,8 @@ see CHANGELOG.md for a more formal list of changes by release
 
 ## todo bucket (no particular order)
 
+* http, revisit the http/expiry-offset-hours value
+
 * robustness, only download/update the catalogue *after* an existing catalogue has been confirmed
     - github is down, wowman is erroring with a 500
     - failure to download a catalogue shouldn't prevent addons from being displayed

--- a/TODO.md
+++ b/TODO.md
@@ -111,6 +111,16 @@ see CHANGELOG.md for a more formal list of changes by release
 
 ## todo bucket (no particular order)
 
+* robustness, only download/update the catalogue *after* an existing catalogue has been confirmed
+    - github is down, wowman is erroring with a 500
+    - failure to download a catalogue shouldn't prevent addons from being displayed
+    - bundle a catalogue with the installation?
+        - load it as a resource with static-slurp, like we do with the sql?
+            - also compressed so it's tiny?
+        - behind the scenes we download and load the full-catalogue
+            - would this block reconciliation?
+                - perhaps if there are unmatched addons after reconciliation we then wait and try again ...?
+
 * game track list in catalogue
     - can game-track-list be included from all other hosts?
         - not just wowi?

--- a/TODO.md
+++ b/TODO.md
@@ -113,6 +113,12 @@ see CHANGELOG.md for a more formal list of changes by release
 
 * http, revisit the http/expiry-offset-hours value
 
+* performance, check addons for updates immediately after loading
+    - if after we've read the nfo data and we have everything we need, check the addon for updates immediately
+        - don't wait for db loading and addon matching
+            - we already have a match!
+        - this might fit in with the greater-parallelism/queue based infrastructure
+
 * robustness, only download/update the catalogue *after* an existing catalogue has been confirmed
     - github is down, wowman is erroring with a 500
     - failure to download a catalogue shouldn't prevent addons from being displayed
@@ -146,6 +152,7 @@ see CHANGELOG.md for a more formal list of changes by release
     * core.clj is getting too large
         - it's difficult to navigate and debug
         - many tests are accumulating in core_test.clj
+
 * wowman-data, stop publishing a 'daily' release
     - we have multiple catalogs now
     - 0.10.0 uses the raw catalog files directly

--- a/TODO.md
+++ b/TODO.md
@@ -112,6 +112,7 @@ see CHANGELOG.md for a more formal list of changes by release
 ## todo bucket (no particular order)
 
 * http, revisit the http/expiry-offset-hours value
+    - also, revisit prune-http-cache
 
 * performance, check addons for updates immediately after loading
     - if after we've read the nfo data and we have everything we need, check the addon for updates immediately

--- a/project.clj
+++ b/project.clj
@@ -26,11 +26,11 @@
                  [seancorfield/next.jdbc "1.0.6"]
 
 
-                 [gui-diff "0.6.7"]
-
                  ;; remember to update the LICENCE.txt
                  ;; remember to update pom file (`lein pom`)
 
+                 [gui-diff "0.6.7"]
+                 [com.taoensso/tufte "2.1.0"]
                  ]
 
   ;; java 11 , java-time localisation issue 

--- a/project.clj
+++ b/project.clj
@@ -41,7 +41,7 @@
   :main strongbox.main
 
   :plugins [[lein-cljfmt "0.6.4"]
-            [jonase/eastwood "0.3.5"]
+            [jonase/eastwood "0.3.10"]
             [lein-cloverage "1.1.1"]]
   :eastwood {:exclude-linters [:constant-test]
              :add-linters [:unused-namespaces

--- a/src/strongbox/core.clj
+++ b/src/strongbox/core.clj
@@ -488,7 +488,7 @@
       :else nil)))
 
 (defn-spec guess-game-track ::sp/game-track
-  "give a map of addon data, attempts to guess the most likely game track it belongs to"
+  "given a map of addon data, attempts to guess the most likely game track it belongs to"
   [install-dir ::sp/extant-dir, addon map?]
   (or (:game-track addon) ;; from reading an export record. most of the time this value won't be here
       (:installed-game-track addon) ;; re-use the value we have if updating an existing addon
@@ -905,8 +905,7 @@
   []
   (when (and (not (db-catalogue-loaded?))
              (current-catalogue))
-    (let [catalogue-source (current-catalogue)
-          catalogue-path (catalogue-local-path catalogue-source)
+    (let [catalogue-path (catalogue-local-path (current-catalogue))
           _ (info (format "loading catalogue '%s'" (name (get-state :cfg :selected-catalogue))))
           _ (debug "loading addon summaries from catalogue into database:" catalogue-path)
 
@@ -1188,7 +1187,7 @@
         upgrade-nfo (partial -upgrade-nfo install-dir)]
     (->> (get-state)
          :installed-addon-list
-         (filter has-nfo-file?) ;; only upgrade addons that nfo files
+         (filter has-nfo-file?) ;; only upgrade addons that have nfo files
          (remove has-valid-nfo-file?) ;; skip good nfo files
          (mapv upgrade-nfo)))
   nil)
@@ -1212,7 +1211,7 @@
   ;; 2019-06-30, travis is failing with 403: Forbidden. Moved to gui init
   ;;(latest-strongbox-release) ;; check for updates after everything else is done 
 
-  (upgrade-nfo-files)     ;; otherwise nfo data is only updated when an addon is installed/upgraded
+  (upgrade-nfo-files)     ;; otherwise nfo data is only updated when an addon is installed or updated
 
   (save-settings)         ;; seems like a good place to preserve the etag-db
   nil)

--- a/src/strongbox/http.clj
+++ b/src/strongbox/http.clj
@@ -208,6 +208,9 @@
     (error (http-error http-resp))))
 
 (defn-spec download (s/or :ok-file ::sp/extant-file, :ok-body string?, :error ::sp/http-error)
+  "downloads the given `url` assuming a textual response, returning the body as a simple string.
+  on http error, an error map with details is returned.
+  an optional `message` can be supplied as the second argument that will be displayed on a cache miss."
   ([url ::sp/url]
    (download url nil))
   ([url ::sp/url, message (s/nilable ::sp/short-string)]
@@ -219,6 +222,10 @@
        (fs/file? resp) (slurp resp))))) ;; file on disk + caching enabled
 
 (defn-spec download-file (s/or :file ::sp/extant-file, :error ::sp/http-error)
+  "downloads the given `url` to the given `output-file`, assuming a bytestream response.
+  returns the path to the file on success.
+  on http error, an error map with details is returned.
+  an optional `message` can be supplied as the second argument that will be displayed on a cache miss."
   ([url ::sp/url, output-file ::sp/file]
    (download-file url output-file nil))
   ([url ::sp/url, output-file ::sp/file, message (s/nilable ::sp/short-string)]

--- a/src/strongbox/http.clj
+++ b/src/strongbox/http.clj
@@ -183,6 +183,7 @@
   [http-err ::sp/http-error]
   (let [key (-> http-err (select-keys [:host :status]) vals set)]
     (condp (comp clojure.set/intersection =) key
+      ;; todo: test this
       #{"raw.github.com" 500} "Github: service is down. Check www.githubstatus.com and try again later."
 
       ;; github api quota exceeded OR github thinks we were making requests too quickly

--- a/src/strongbox/logging.clj
+++ b/src/strongbox/logging.clj
@@ -1,12 +1,43 @@
 (ns strongbox.logging
   (:require
    [taoensso.timbre :as logging :refer [spy]]
+   [taoensso.timbre.appenders.core :refer [spit-appender]]
    [taoensso.tufte :as tufte :refer [p profile]]
    [orchestra.core :refer [defn-spec]]
    [orchestra.spec.test :as st]
    [strongbox
     [specs :as sp]
     [utils :refer [join]]]))
+
+;; profiling
+
+;; print any profiling to stdout
+(tufte/add-basic-println-handler! {})
+
+(defn-spec add-profiling-handler! nil?
+  "writes profiling data to a timestamped file in the given `output-dir`"
+  [output-dir ::sp/extant-dir]
+  (let [output-file (logging/spy :info (join output-dir (str (java-time/instant) ".pstats")))]
+    (tufte/add-handler!
+     :data-dir-logger "*"
+     (fn [data-map]
+       (try
+         (spit output-file (tufte/format-pstats (:pstats data-map) nil))
+         (catch Exception uncaught-exception
+           (logging/error uncaught-exception "uncaught exception attempting to write pstats file"))))))
+  nil)
+
+;; logging
+
+(defn-spec debug-mode? boolean?
+  "debug mode is when the log level has been set to 'debug' and we're *not* running tests.
+  the intent is to collect as much information around a problem as possible.
+  the log level may change during REPL usage. 
+  the log level may change by passing in a 'verbosity' flag.
+  `main.clj` adds an adhoc 'testing?' flag to the logging configuration and removes it afterwards."
+  []
+  (and (-> logging/*config* :level (= :debug))
+       (not (-> logging/*config* :testing?))))
 
 (defn anon-println-appender
   "removes the hostname from the output format string"
@@ -28,15 +59,23 @@
 
 (logging/merge-config! default-logging-config)
 
-(defn-spec add-appender nil?
+(defn-spec add-appender! nil?
   "adds appender at `key` to logging config"
   ([key keyword?, f fn?]
-   (add-appender key f {}))
+   (add-appender! key f {}))
   ([key keyword?, f fn?, config map?]
    (logging/debug "adding appender" key config)
    (let [appender-config (merge {:fn f, :enabled? true} config)]
      (logging/merge-config! {:appenders {key appender-config}})
      nil)))
+
+(defn-spec add-file-appender! nil?
+  [output-dir ::sp/extant-dir]
+  (let [output-file (join output-dir "debug.log")
+        ;; urgh. a little too clever.
+        func (:fn (spit-appender {:fname output-file}))]
+    (add-appender! :spit func))
+  nil)
 
 (defn-spec rm-appender! nil?
   "removes appender at `key` from logging config"
@@ -56,27 +95,8 @@
        ~@form)
      (deref stateful-buffer#)))
 
-(defn-spec change-log-level nil?
-  [new-level keyword?]
-  (when new-level
-    (logging/merge-config! {:level new-level}))
-  nil)
 
 ;;
 
-(defn-spec add-profiling-handler! nil?
-  "writes profiling data to a timestamped file in the given `output-dir`"
-  [output-dir ::sp/extant-dir]
-  (let [output-file (logging/spy :info (join output-dir (str (java-time/instant) ".pstats")))]
-    (tufte/add-handler!
-     :data-dir-logger "*"
-     (fn [data-map]
-       (try
-         (spit output-file (tufte/format-pstats (:pstats data-map) nil))
-         (catch Exception uncaught-exception
-           (logging/error uncaught-exception "uncaught exception attempting to write pstats file"))))))
-  nil)
-
-;;
 
 (st/instrument)

--- a/src/strongbox/main.clj
+++ b/src/strongbox/main.clj
@@ -70,7 +70,7 @@
   [& [ns-kw fn-kw]]
   (clojure.tools.namespace.repl/refresh) ;; reloads all namespaces, including strongbox.whatever-test ones
   (timbre/with-merged-config {:level :debug, :testing? true
-                              ;; ensure we're not writing to any files
+                              ;; ensure we're not writing logs to files
                               :appenders {:spit nil}}
     (if ns-kw
       (if (some #{ns-kw} [:main :utils :http :specs :tags

--- a/src/strongbox/main.clj
+++ b/src/strongbox/main.clj
@@ -69,7 +69,9 @@
 (defn test
   [& [ns-kw fn-kw]]
   (clojure.tools.namespace.repl/refresh) ;; reloads all namespaces, including strongbox.whatever-test ones
-  (timbre/with-merged-config {:level :debug, :testing? true}
+  (timbre/with-merged-config {:level :debug, :testing? true
+                              ;; ensure we're not writing to any files
+                              :appenders {:spit nil}}
     (if ns-kw
       (if (some #{ns-kw} [:main :utils :http :specs :tags
                           :core :toc :nfo :zip :config :catalogue

--- a/src/strongbox/main.clj
+++ b/src/strongbox/main.clj
@@ -50,11 +50,12 @@
 
 (defn start
   [& [cli-opts]]
-  (profile {}
-           (p :core-start (core/start (or cli-opts {})))
-           (if (= :cli (:ui cli-opts))
-             (p :ui-start (cli/start cli-opts))
-             (p :gui-start (gui/start))))
+  (profile
+   {}
+   (p :core-start (core/start (or cli-opts {})))
+   (if (= :cli (:ui cli-opts))
+     (p :ui-start (cli/start cli-opts))
+     (p :gui-start (gui/start))))
 
   (watch-for-gui-restart)
 

--- a/src/strongbox/main.clj
+++ b/src/strongbox/main.clj
@@ -7,6 +7,7 @@
    [clojure.tools.namespace.repl :as tn :refer [refresh]]
    [clojure.string :refer [lower-case]]
    [me.raynes.fs :as fs]
+   [taoensso.tufte :as tufte :refer [p profile]]
    [strongbox
     [logging :as logging]
     [core :as core]
@@ -21,6 +22,8 @@
  (reify Thread$UncaughtExceptionHandler
    (uncaughtException [_ thread ex]
      (error ex "Uncaught exception on" (.getName thread)))))
+
+(tufte/add-basic-println-handler! {})
 
 (defn watch-for-gui-restart
   "monitors application state for requests to restart the gui.
@@ -47,10 +50,11 @@
 
 (defn start
   [& [cli-opts]]
-  (core/start (or cli-opts {}))
-  (if (= :cli (:ui cli-opts))
-    (cli/start cli-opts)
-    (gui/start))
+  (profile {}
+           (p :core-start (core/start (or cli-opts {})))
+           (if (= :cli (:ui cli-opts))
+             (p :ui-start (cli/start cli-opts))
+             (p :gui-start (gui/start))))
 
   (watch-for-gui-restart)
 

--- a/src/strongbox/ui/gui.clj
+++ b/src/strongbox/ui/gui.clj
@@ -649,7 +649,7 @@
       (.setPreferredWidth (* level-width 1.5))
       (.setCellRenderer cell-renderer))
 
-    (logging/add-appender :gui gui-logger {:timestamp-opts {:pattern "HH:mm:ss"}})
+    (logging/add-appender! :gui gui-logger {:timestamp-opts {:pattern "HH:mm:ss"}})
 
     (add-highlighter grid #(= (.getValue % level-col-idx) :warn) (colours :notice/warning))
     (add-highlighter grid #(= (.getValue % level-col-idx) :error) (colours :notice/error))

--- a/src/strongbox/ui/gui.clj
+++ b/src/strongbox/ui/gui.clj
@@ -885,9 +885,10 @@
                      (ss/action :name "Export addon list" :handler (async-handler export-addon-list-handler))
                      (ss/action :name "Export Github addon list" :handler (async-handler export-user-catalogue-handler))]
 
-        cache-menu [(ss/action :name "Clear cache" :handler (async-handler core/delete-cache!))
+        cache-menu [(ss/action :name "Clear http cache" :handler (async-handler core/delete-http-cache!))
                     (ss/action :name "Clear addon zips" :handler (async-handler core/delete-downloaded-addon-zips!))
                     (ss/action :name "Clear catalogues" :handler (async-handler (juxt core/db-reload-catalogue core/delete-catalogue-files!)))
+                    (ss/action :name "Clear log files" :handler (async-handler core/delete-log-files!))
                     (ss/action :name "Clear all" :handler (async-handler core/clear-all-temp-files!))
                     :separator
                     (ss/action :name "Delete WowMatrix.dat files" :handler (async-handler core/delete-wowmatrix-dat-files!))

--- a/src/strongbox/utils.clj
+++ b/src/strongbox/utils.clj
@@ -97,7 +97,9 @@
         expiry-offset (jt/hours hours)
         expiry-date (jt/plus modtime expiry-offset)
         expired? (jt/before? expiry-date now)]
-    (debug (format "path %s; modtime %s; expiry-offset %s; expiry-date %s; now %s; expired? %s" file modtime expiry-offset expiry-date now expired?))
+    (when expired?
+      ;; too noisy even for :debug when nothing has expired
+      (debug (format "path %s; modtime %s; expiry-offset %s; expiry-date %s; now %s; expired? %s" file modtime expiry-offset expiry-date now expired?)))
     expired?))
 
 (defn-spec days-between-then-and-now int?


### PR DESCRIPTION
An attempt to identify the slowest parts of wowman and make clearer (in the code) the general flow of logic. `core.clj` has gotten a little soupy and could benefit from some sharpening up.

- [x] if log level is set to DEBUG, enable profiling, except when testing.
- [x] dump profile data to a file. I need to track improvements over time somehow.
- [x] if log level is set to DEBUG, write log to file, except when testing.
- [x] add log removal to cleanup operations. this should include profile data logs too.
- [x] review
- [ ] ~update ticket template on command to run with switches to use and files to upload~
    - deferred until last minute, otherwise it might get confusing for `wowman` users