### PR TITLE
preferences, automatic update-all

### DIFF
--- a/src/strongbox/specs.clj
+++ b/src/strongbox/specs.clj
@@ -122,7 +122,10 @@
 (s/def ::selected-catalogue keyword?)
 
 (s/def :config/addon-zips-to-keep (s/nilable int?))
-(s/def :config/preferences (s/keys :req-un [:config/addon-zips-to-keep]))
+(s/def :config/automatic-update-all boolean?)
+(s/def :config/preferences (s/keys :req-un [:config/addon-zips-to-keep
+                                            :config/automatic-update-all
+                                            ]))
 
 (s/def ::user-config (s/keys :req-un [::addon-dir-list ::selected-addon-dir
                                       ::catalogue-location-list ::selected-catalogue

--- a/src/strongbox/ui/jfx.clj
+++ b/src/strongbox/ui/jfx.clj
@@ -1019,10 +1019,19 @@
         selected? (not (nil? num-addon-zips-to-keep)) ;; `nil` is 'keep all zips', see `config.clj`
         ]
     {:fx/type :check-menu-item
-     :text "Remove addon zip after installation (global)"
+     :text "Remove addon zip after installation" ;; (global)" 
      :selected selected?
      :on-action (fn [ev]
                   (cli/set-preference :addon-zips-to-keep (if (.isSelected (.getSource ev)) 0 nil)))}))
+
+(defn menu-item--automatic-update-all
+  [{:keys [fx/context]}]
+  (let [selected? (fx/sub-val context get-in [:app-state :cfg :preferences :automatic-update-all])]
+    {:fx/type :check-menu-item
+     :text "Update addons immediately"
+     :selected selected?
+     :on-action (fn [ev]
+                  (cli/set-preference :automatic-update-all (.isSelected (.getSource ev))))}))
 
 (defn menu-bar
   "returns a description of the menu at the top of the application"
@@ -1049,7 +1058,9 @@
                    separator
                    (menu-item "E_xit" exit-handler {:key "Ctrl+Q"})]
 
-        prefs-menu [{:fx/type menu-item--num-zips-to-keep}]
+        prefs-menu [{:fx/type menu-item--num-zips-to-keep}
+                    {:fx/type menu-item--automatic-update-all}
+                    ]
 
         view-menu (into
                    [(menu-item "Refresh" (async-handler cli/hard-refresh) {:key "F5"})

--- a/test/fixtures/user-config-4.2.json
+++ b/test/fixtures/user-config-4.2.json
@@ -1,0 +1,49 @@
+{
+  "gui-theme": "dark-green",
+  "addon-dir-list": [
+    {
+      "addon-dir": "/tmp/.strongbox-bar",
+      "game-track": "classic-tbc",
+      "strict?": true
+    },
+    {
+      "addon-dir": "/tmp/.strongbox-foo",
+      "game-track": "retail",
+      "strict?": false
+    }
+  ],
+  "selected-addon-dir": "/tmp/.strongbox-foo",
+  "catalogue-location-list": [
+    {
+      "name": "short",
+      "label": "Short (default)",
+      "source": "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/short-catalogue.json"
+    },
+    {
+      "name": "full",
+      "label": "Full",
+      "source": "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/full-catalogue.json"
+    },
+    {
+      "name": "tukui",
+      "label": "Tukui",
+      "source": "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/tukui-catalogue.json"
+    },
+    {
+      "name": "curseforge",
+      "label": "Curseforge",
+      "source": "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/curseforge-catalogue.json"
+    },
+    {
+      "name": "wowinterface",
+      "label": "WoWInterface",
+      "source": "https://raw.githubusercontent.com/ogri-la/strongbox-catalogue/master/wowinterface-catalogue.json"
+    }
+  ],
+  "selected-catalogue": "full",
+  "preferences":
+  {
+      "addon-zips-to-keep": 3,
+      "automatic-update-all": true
+  }
+}

--- a/test/strongbox/config_test.clj
+++ b/test/strongbox/config_test.clj
@@ -192,7 +192,10 @@
                           :selected-addon-dir "/tmp/.strongbox-bar" ;; defaults to first entry
 
                           ;; new in 3.1.0
-                          :preferences {:addon-zips-to-keep nil}}
+                          :preferences {;; new in 3.1.0
+                                        :addon-zips-to-keep nil
+                                        ;; new in 4.2.0
+                                        :automatic-update-all false}}
 
                     :cli-opts {}
                     :file-opts {:debug? true
@@ -221,7 +224,10 @@
                           :selected-addon-dir "/tmp/.strongbox-bar"
 
                           ;; new in 3.1.0
-                          :preferences {:addon-zips-to-keep nil}}
+                          :preferences {;; new in 3.1.0
+                                        :addon-zips-to-keep nil
+                                        ;; new in 4.2.0
+                                        :automatic-update-all false}}
 
                     :cli-opts {}
                     :file-opts {:selected-catalogue :full
@@ -251,13 +257,15 @@
                           :selected-addon-dir "/tmp/.strongbox-bar"
 
                           ;; new in 3.1.0
-                          :preferences {:addon-zips-to-keep nil}}
+                          :preferences {;; new in 3.1.0
+                                        :addon-zips-to-keep nil
+                                        ;; new in 4.2.0
+                                        :automatic-update-all false}}
 
                     :cli-opts {}
                     :file-opts {:gui-theme :dark
                                 :selected-catalogue :full
                                 :debug? true
-                                ;; todo: shouldn't these have `:strict?` in them?
                                 :addon-dir-list [{:addon-dir "/tmp/.strongbox-bar", :game-track :retail}
                                                  {:addon-dir "/tmp/.strongbox-foo", :game-track :classic}]}
                     :etag-db {}}]
@@ -282,7 +290,10 @@
                           :selected-addon-dir "/tmp/.strongbox-bar"
 
                           ;; new in 3.1.0
-                          :preferences {:addon-zips-to-keep nil}}
+                          :preferences {;; new in 3.1.0
+                                        :addon-zips-to-keep nil
+                                        ;; new in 4.2.0
+                                        :automatic-update-all false}}
 
                     :cli-opts {}
                     :file-opts {:gui-theme :dark
@@ -312,7 +323,10 @@
                           :selected-addon-dir "/tmp/.strongbox-foo"
 
                           ;; new in 3.1.0
-                          :preferences {:addon-zips-to-keep nil}}
+                          :preferences {;; new in 3.1.0
+                                        :addon-zips-to-keep nil
+                                        ;; new in 4.2.0
+                                        :automatic-update-all false}}
 
                     :cli-opts {}
                     :file-opts {:gui-theme :dark
@@ -320,10 +334,7 @@
                                 :addon-dir-list [{:addon-dir "/tmp/.strongbox-bar", :game-track :retail}
                                                  {:addon-dir "/tmp/.strongbox-foo", :game-track :classic}]
                                 :selected-addon-dir "/tmp/.strongbox-foo"
-
-                                ;; new in 1.0
                                 :catalogue-location-list (:catalogue-location-list config/default-cfg)}
-
                     :etag-db {}}]
       (is (= expected (config/load-settings cli-opts cfg-file etag-db-file))))))
 
@@ -348,7 +359,10 @@
                           :selected-addon-dir "/tmp/.strongbox-foo"
 
                           ;; new in 3.1.0
-                          :preferences {:addon-zips-to-keep 3}}
+                          :preferences {;; new in 3.1.0
+                                        :addon-zips-to-keep 3
+                                        ;; new in 4.2.0
+                                        :automatic-update-all false}}
 
                     :cli-opts {}
                     :file-opts {:gui-theme :dark
@@ -356,8 +370,6 @@
                                 :addon-dir-list [{:addon-dir "/tmp/.strongbox-bar", :game-track :retail-classic}
                                                  {:addon-dir "/tmp/.strongbox-foo", :game-track :classic}]
                                 :selected-addon-dir "/tmp/.strongbox-foo"
-
-                                ;; new in 1.0
                                 :catalogue-location-list (:catalogue-location-list config/default-cfg)
 
                                 :preferences {:addon-zips-to-keep 3}}
@@ -386,7 +398,10 @@
                           :selected-addon-dir "/tmp/.strongbox-foo"
 
                           ;; new in 3.1.0
-                          :preferences {:addon-zips-to-keep 3}}
+                          :preferences {;; new in 3.1.0
+                                        :addon-zips-to-keep 3
+                                        ;; new in 4.2.0
+                                        :automatic-update-all false}}
 
                     :cli-opts {}
                     :file-opts {:gui-theme :dark-green
@@ -394,12 +409,8 @@
                                 :addon-dir-list [{:addon-dir "/tmp/.strongbox-bar", :game-track :retail-classic}
                                                  {:addon-dir "/tmp/.strongbox-foo", :game-track :classic}]
                                 :selected-addon-dir "/tmp/.strongbox-foo"
-
-                                ;; new in 1.0
                                 :catalogue-location-list (:catalogue-location-list config/default-cfg)
-
                                 :preferences {:addon-zips-to-keep 3}}
-
                     :etag-db {}}]
       (is (= expected (config/load-settings cli-opts cfg-file etag-db-file))))))
 
@@ -423,7 +434,10 @@
                           :selected-addon-dir "/tmp/.strongbox-foo"
 
                           ;; new in 3.1.0
-                          :preferences {:addon-zips-to-keep 3}}
+                          :preferences {;; new in 3.1.0
+                                        :addon-zips-to-keep 3
+                                        ;; new in 4.2.0
+                                        :automatic-update-all false}}
 
                     :cli-opts {}
                     :file-opts {:gui-theme :dark-green
@@ -431,11 +445,46 @@
                                 :addon-dir-list [{:addon-dir "/tmp/.strongbox-bar", :game-track :classic-tbc, :strict? true}
                                                  {:addon-dir "/tmp/.strongbox-foo", :game-track :retail, :strict? false}]
                                 :selected-addon-dir "/tmp/.strongbox-foo"
+                                :catalogue-location-list (:catalogue-location-list config/default-cfg)
+                                :preferences {:addon-zips-to-keep 3}}
+                    :etag-db {}}]
+      (is (= expected (config/load-settings cli-opts cfg-file etag-db-file))))))
 
-                                ;; new in 1.0
+(deftest load-settings-4.2
+  (testing "a standard config file circa 4.2 is loaded and parsed as expected"
+    (let [cli-opts {}
+          cfg-file (fixture-path "user-config-4.2.json")
+          etag-db-file (fixture-path "empty-map.json")
+
+          expected {:cfg {:gui-theme :dark-green ;; new in 0.11, `:dark-green` new in 3.2.0
+                          :selected-catalogue :full ;; new in 0.10
+                          ;;:debug? true ;; removed in 0.12
+                          :addon-dir-list [{:addon-dir "/tmp/.strongbox-bar", :game-track :classic-tbc :strict? true} ;; `:classic-tbc` and `:strict?` added in 4.1
+                                           {:addon-dir "/tmp/.strongbox-foo", :game-track :retail :strict? false}]
+
+                          ;; new in 1.0
+                          :catalogue-location-list (:catalogue-location-list config/default-cfg)
+
+                          ;; new in 0.12
+                          ;; moved to :cfg in 1.0
+                          :selected-addon-dir "/tmp/.strongbox-foo"
+
+                          ;; new in 3.1.0
+                          :preferences {;; new in 3.1.0
+                                        :addon-zips-to-keep 3
+                                        ;; new in 4.2.0
+                                        :automatic-update-all true}}
+
+                    :cli-opts {}
+                    :file-opts {:gui-theme :dark-green
+                                :selected-catalogue :full
+                                :addon-dir-list [{:addon-dir "/tmp/.strongbox-bar", :game-track :classic-tbc, :strict? true}
+                                                 {:addon-dir "/tmp/.strongbox-foo", :game-track :retail, :strict? false}]
+                                :selected-addon-dir "/tmp/.strongbox-foo"
                                 :catalogue-location-list (:catalogue-location-list config/default-cfg)
 
-                                :preferences {:addon-zips-to-keep 3}}
+                                :preferences {:addon-zips-to-keep 3
+                                              :automatic-update-all true}}
 
                     :etag-db {}}]
       (is (= expected (config/load-settings cli-opts cfg-file etag-db-file))))))


### PR DESCRIPTION
adds a preference that will allow addon updates to happen immediately after the app starts, rather than click that 'update all' button

- [ ] update README features
- [ ] review
- [ ] update CHANGELOG